### PR TITLE
Removed notepad.exe at the end

### DIFF
--- a/payloads/library/DuckyTemplate/payload.txt
+++ b/payloads/library/DuckyTemplate/payload.txt
@@ -31,4 +31,4 @@ else
     LED R
     echo "Unable to load ducky_script.txt" >> /root/debuglog.txt
         exit 1
-finotepad.exe
+fi


### PR DESCRIPTION
Removed the extra notepad.exe at the end that was combined with 'fi', caused second if statement to fail.