### PR TITLE
Updated install.sh to solve problems mentioned in forum

### DIFF
--- a/payloads/library/Captiveportal/payload.txt
+++ b/payloads/library/Captiveportal/payload.txt
@@ -4,6 +4,9 @@
 # Author:        Sebkinne
 # Version:       1.0
 
+# Usage of bunny_helpers.sh to avoid problems with find in function startCaptiveportal
+https://forums.hak5.org/index.php?/topic/40237-install-tools/
+
 # Add or remove inputs here
 INPUTS=(username password)
 
@@ -27,7 +30,8 @@ function setupNetworking() {
 
 # Find payload directory and execute payload
 function startCaptiveportal() {
-    cd $(dirname $(find /root/udisk/payloads/ -name portal.html))
+#    cd $(dirname $(find /root/udisk/payloads/ -name portal.html))
+    cd /root/udisk/payloads/$SWITCH_POSITION
     chmod +x captiveportal
     ./captiveportal ${INPUTS[@]}
 }

--- a/payloads/library/tools_installer/install.sh
+++ b/payloads/library/tools_installer/install.sh
@@ -1,6 +1,10 @@
+# To avoid the use of find in the next section, let's verify the switch position
+# and therefore the exact position of tools_to_install
+source bunny_helpers.sh
+
 # Check to ensure that the tools_to_install directory isn't empty. 
 # Exit with solid red LED if it is, otherwise note tools in log.
-TOOLSDIR=$(find /root/udisk/payloads/ -name tools_to_install)
+TOOLSDIR=/root/udisk/payloads/$SWITCH_POSITION/tools_to_install/
 if [ "$(ls -A $TOOLSDIR)" ]; then
     cd $TOOLSDIR
 	echo "Available Tools:" > /tmp/tools_installer.log
@@ -15,6 +19,9 @@ fi
 LED R B 100
 mkdir -p /pentest
 mv $TOOLSDIR/* /pentest/
+
+# Be sure that there are no OS made hidden files in the directory
+rm .*
 
 # Set LED to purple solid and check that move completed
 LED R B


### PR DESCRIPTION
Within the hak5 forum https://forums.hak5.org/index.php?/topic/40237-install-tools/
there were several problems mentioned which are solved with this update:

1. No need to move instead of copying tools_to_install to the switch directory due to use of bunny_helpers.sh
2. Check if everything is copied works even when the user OS has added hidden files (removing hidden files before test)