### PR TITLE
Added .gitignore file to ignore default Mac OSX files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store


### PR DESCRIPTION
When developing on a mac, lots of '.DS_Store' files appear in each directory. This ignore will stop them being tracked by git