### PR TITLE
Config Payloads to run off of a Config file

### DIFF
--- a/config_sample.txt
+++ b/config_sample.txt
@@ -1,0 +1,2 @@
+switch1:MacReverseShell
+switch2:smb_exfiltrator

--- a/config_sample.txt
+++ b/config_sample.txt
@@ -1,2 +1,2 @@
-switch1:MacReverseShell
-switch2:smb_exfiltrator
+switch1:payloads/library/MacReverseShell
+switch2:payloads/library/smb_exfiltrator

--- a/payloads/library/ConfigPayloads/install.sh
+++ b/payloads/library/ConfigPayloads/install.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# oh man. you trust me to edit your primary bunny file? you have balls, my friend
+# but for real, if this fails, just reboot bunny 3 more times and it'll recover. 
+
+source bunny_helpers.sh
+
+LED B
+# I wouldn't touch this unless you know what you're doing
+LOG_FILE=/tmp/config_payloads.log
+OLD_FILE=/root/bash_bunny.sh
+NEW_FILE=/root/udisk/payloads/${SWITCH_POSITION}/new_bash_bunny.sh
+
+
+echo "Install Log:" > $LOG_FILE
+echo "----------------" >> $LOG_FILE
+
+if [ -f ${NEW_FILE} ]; then
+        echo "Found ${NEW_FILE}" >> $LOG_FILE
+else
+    LED R
+    echo "No Bueno. Missing File. Did you forget to move it? You need this more than you realize" >> $LOG_FILE
+    cp $LOG_FILE /root/udisk/payloads/${SWITCH_POSITION}/install_log.txt
+        exit 1
+fi
+
+# purple means work is being done.
+LED R B 100
+
+# Backup Existing Bash Bunny
+if [ -f $OLD_FILE ]; then
+    echo "Moving the old file." >> $LOG_FILE
+    mv  $OLD_FILE /root/old_bash_bunny.sh
+fi
+
+echo "Copying new bash bunny" >> $LOG_FILE
+cp $NEW_FILE $OLD_FILE
+chmod +x $OLD_FILE
+
+FILE_SIZE=$(wc -c <"$OLD_FILE")
+if [ $FILE_SIZE -ge 80 ]; then
+     LED G
+     echo "File copy a success" >> $LOG_FILE
+else
+     LED R 100
+     echo "File copy failed, reverting" >> $LOG_FILE
+     rm $OLD_FILE
+     mv /root/old_bash_bunny.sh $OLD_FILE
+fi
+
+cp $LOG_FILE /root/udisk/payloads/${SWITCH_POSITION}/install_log.txt

--- a/payloads/library/ConfigPayloads/new_bash_bunny.sh
+++ b/payloads/library/ConfigPayloads/new_bash_bunny.sh
@@ -68,7 +68,7 @@ set_payload() {
 	config_file=$udisk_folder/config.txt
 	if [ -f $config_file ]; then
 		payload=$(cat $config_file | grep $switch | awk -F: '{print $2}')
-		payload_dir=$udisk_folder/payloads/library/$payload
+		payload_dir=$udisk_folder/$payload
 	fi
 	payload_file=$payload_dir/payload.txt
 }
@@ -105,7 +105,7 @@ run_script() {
 			echo DUCKY_LANG = $DUCKY_LANG
 			export DUCKY_LANG
 
-			# run install.sh in /payloads/$switch/ if it exists
+			# run install.sh in $payload_dir if it exists
 			local install_file=$payload_dir/install.sh
 			if [ -f $install_file ]; then
 				# make a copy of install.sh file to /tmp/ folder

--- a/payloads/library/ConfigPayloads/new_bash_bunny.sh
+++ b/payloads/library/ConfigPayloads/new_bash_bunny.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+
+start_bunny() {
+	echo ========== Starting Bash Bunny ...
+	dmesg -c > /dev/null
+
+	# disable usb otg
+	echo 0 > /sys/bus/platform/devices/sunxi_usb_udc/otg_role
+	cat /sys/bus/platform/devices/sunxi_usb_udc/otg_role
+
+	# blink green led
+	/root/tools/blink_led.sh green 1000 &
+
+	# To disable the message "INFO: task vsync proc 0:58 blocked for more than 120 seconds."
+	echo 0 > /proc/sys/kernel/hung_task_timeout_secs
+
+	# clear bootcount
+	bootcountpart=/dev/nanda
+	bootcountfolder=/root/bootcount
+	mkdir -p $bootcountfolder
+
+	mount -t vfat $bootcountpart $bootcountfolder
+	echo "0" > $bootcountfolder/bootcnt.txt
+	if [ -f $bootcountfolder/tar_fail.txt ]; then
+		rm $bootcountfolder/tar_fail.txt
+	fi
+	umount $bootcountpart
+}
+
+# start bunny platform
+start_bunny
+
+
+do_mount() {
+#	private_folder=/root/private
+#	mkdir -p $private_folder
+#	mount -t ext4 /dev/nandg $private_folder
+#	private_folder=/root/private/private
+
+	udisk_folder=/root/udisk
+	mkdir -p $udisk_folder
+	mount /dev/nandf $udisk_folder
+}
+
+do_unmount() {
+#	umount /dev/nandg	# private/sysrecovery partition
+	umount /dev/nandf	# mass storage partition
+}
+
+check_switch() {
+	switch1=`cat /sys/class/gpio_sw/PA8/data`
+	switch2=`cat /sys/class/gpio_sw/PL4/data`
+	switch3=`cat /sys/class/gpio_sw/PL3/data`
+	echo "--- switch1 = $switch1, switch2 = $switch2, switch3 = $switch3"
+	if [ "x$switch1" = "x0" ] && [ "x$switch2" = "x1" ] && [ "x$switch3" = "x1" ]; then
+		switch="switch1"
+	elif [ "x$switch1" = "x1" ] && [ "x$switch2" = "x0" ] && [ "x$switch3" = "x1" ]; then
+		switch="switch2"
+	elif [ "x$switch1" = "x1" ] && [ "x$switch2" = "x1" ] && [ "x$switch3" = "x0" ]; then
+		switch="switch3"
+	else
+		switch="invalid"
+	fi
+}
+
+set_payload() {
+	payload_dir=$udisk_folder/payloads/$switch
+	config_file=$udisk_folder/config.txt
+	if [ -f $config_file ]; then
+		payload=$(cat $config_file | grep $switch | awk -F: '{print $2}')
+		payload_dir=$udisk_folder/payloads/library/$payload
+	fi
+	payload_file=$payload_dir/payload.txt
+}
+
+################################################################################
+# Run Bash Bunny script /payloads/switch[1|2]/payload.txt
+################################################################################
+
+run_script() {
+	echo switch = $switch =========
+	# bunny attack/automation only happen for switch1 or switch2.
+	if [ "x$switch" = "xswitch1" ] || [ "x$switch" = "xswitch2" ]; then
+		if [ -f $payload_file ]; then
+			# New $PATH is temporarily valid for all .sh scripts
+			#     in folder $udisk_folder/payloads/$switch/.
+			# Note the order of searching path
+			PATH=$payload_dir/:$udisk_folder/payloads/library/:$PATH
+			echo --- PATH = $PATH
+
+			# make a copy of payload file to /tmp/ folder
+			cp $payload_file /tmp/payload.txt
+			payload_file="/tmp/payload.txt"
+			# remove dos format trailing Carriage Return \r
+			sed -i 's/\r//g' $payload_file
+
+			lang_line=$(cat $payload_file | grep 'Q SET_LANGUAGE')
+			if [ "x$lang_line" = "x" ]; then
+				lang_line=$(cat $payload_file | grep 'QUACK SET_LANGUAGE')
+			fi
+			DUCKY_LANG=$(echo $lang_line | awk {'print $3'} | awk '{print tolower($0)}')
+			if [ "x$DUCKY_LANG" = "x" ]; then
+				DUCKY_LANG="us"
+			fi
+			echo DUCKY_LANG = $DUCKY_LANG
+			export DUCKY_LANG
+
+			# run install.sh in /payloads/$switch/ if it exists
+			local install_file=$payload_dir/install.sh
+			if [ -f $install_file ]; then
+				# make a copy of install.sh file to /tmp/ folder
+				cp $install_file /tmp/install.sh
+				install_file="/tmp/install.sh"
+				# remove dos format trailing Carriage Return \r
+				sed -i 's/\r//g' $install_file
+
+				/bin/bash -c "$install_file"
+				local status=$?
+				echo --- Exit status of install.sh is $status
+				if [ $status -eq 0 ]; then
+					mv $payload_dir/install.sh \
+					   $payload_dir/install.sh.INSTALLED
+					sync
+				fi
+			fi
+
+			# Run payload.txt
+			/bin/bash -c "$payload_file"
+		fi
+	else
+		# run maintenance mode when in switch3 position
+		if [ "x$switch" = "xinvalid" ]; then
+			echo --- Wrong switch positions!!!
+		fi
+		killall blink_led.sh
+		/root/tools/blink_led.sh blue 1000 &
+		# sleep 1s for cdc acm driver
+		sleep 1
+		/bin/bash -c "ATTACKMODE SERIAL STORAGE"
+	fi
+}
+
+do_mount
+check_switch
+set_payload
+run_script
+do_unmount
+
+exit 0

--- a/payloads/library/ConfigPayloads/payload.txt
+++ b/payloads/library/ConfigPayloads/payload.txt
@@ -1,0 +1,2 @@
+# See install.sh and readme.txt for details
+ATTACKMODE ECM_ETHERNET STORAGE

--- a/payloads/library/ConfigPayloads/readme.md
+++ b/payloads/library/ConfigPayloads/readme.md
@@ -1,0 +1,28 @@
+# Config Payloads
+
+Author: mrt0mat0
+Version: Version 1.0
+
+## Description
+
+I was sick of copying payloads to the switch folders. I would always forget what I had where, and changes I made in the switch would get overwritten by another payload. 
+
+This script update will allow you to create a config.txt in the root directory (same as payloads) that will allow you to set payloads to point to library directories. keeps it clean. If no file exists, it will default to the switch1, switch2 setup.
+
+## Configuration
+
+You don't need a `config.txt for this to work. However, it's the whole point so I would recommend it. In the root storage directory, create a file called config.txt. in it should have to lines:
+```switch1:MacReverseShell
+switch2:smb_exfiltrator```
+
+that's it. Enjoy!
+
+## STATUS
+
+| LED              | Status                                |
+| ---------------- | ------------------------------------- |
+| Blue             | Running                               |
+| Red              | File Missing (new_bunny_bash.sh       |
+| Purple (blink)   | Copy in progress                      |
+| Red (blink)      | Copy Failed. Reverting.               |
+| Green            | Finished                              |

--- a/payloads/library/ConfigPayloads/readme.md
+++ b/payloads/library/ConfigPayloads/readme.md
@@ -11,9 +11,11 @@ This script update will allow you to create a config.txt in the root directory (
 
 ## Configuration
 
-You don't need a `config.txt for this to work. However, it's the whole point so I would recommend it. In the root storage directory, create a file called config.txt. in it should have to lines:
-```switch1:MacReverseShell
-switch2:smb_exfiltrator```
+You don't need a `config.txt` for this to work. However, it's the whole point so I would recommend it. In the root storage directory, create a file called config.txt. in it should have to lines:
+```
+switch1:MacReverseShell
+switch2:smb_exfiltrator
+```
 
 that's it. Enjoy!
 

--- a/payloads/library/ConfigPayloads/readme.md
+++ b/payloads/library/ConfigPayloads/readme.md
@@ -13,8 +13,8 @@ This script update will allow you to create a config.txt in the root directory (
 
 You don't need a `config.txt` for this to work. However, it's the whole point so I would recommend it. In the root storage directory, create a file called config.txt. in it should have to lines:
 ```
-switch1:MacReverseShell
-switch2:smb_exfiltrator
+switch1:/payloads/library/MacReverseShell
+switch2:/payloads/switch1
 ```
 
 that's it. Enjoy!

--- a/payloads/library/ConfigPayloads/readme.md
+++ b/payloads/library/ConfigPayloads/readme.md
@@ -11,10 +11,10 @@ This script update will allow you to create a config.txt in the root directory (
 
 ## Configuration
 
-You don't need a `config.txt` for this to work. However, it's the whole point so I would recommend it. In the root storage directory, create a file called config.txt. in it should have to lines:
+You don't need a `config.txt` for this to work. However, it's the whole point so I would recommend it. In the root storage directory, create a file called config.txt. in it should have two lines:
 ```
-switch1:/payloads/library/MacReverseShell
-switch2:/payloads/switch1
+switch1:payloads/library/MacReverseShell
+switch2:payloads/switch1
 ```
 
 that's it. Enjoy!


### PR DESCRIPTION
Instead of copying files back and forth into switches, why not use this handy dandy config.txt file. create as many new library resources as you'd like. Makes swapping out payloads a breeze!