### PR TITLE
BashBunny debug helpers

### DIFF
--- a/payloads/library/bunny_debug_helpers.sh
+++ b/payloads/library/bunny_debug_helpers.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ################################################################################
-# Allow Debugging messages written to: "/root/udisk/[payload]/debug/debug_[timestamp].txt"
+# Allow Debugging messages written to: "payload/[switch]/debug/debug_[timestamp].txt"
 # on the BashBunny
 #
 # How this works?
@@ -11,7 +11,7 @@
 #	    OR
 #	    debug_log "DEBUG MESSAGE"
 #	    (To write to log with timestamps)
-# 2) After attack, Text can be read at: "/root/udisk/[payload]/debug/debug_[timestamp].txt"
+# 2) After attack, Text can be read at: "payload/[switch]/debug/debug_[timestamp].txt"
 #    on the BashBunny
 # 3) To turn off debugging, pass the OFF comand when including the helper
 #       source bunny_debug_helpers.sh OFF

--- a/payloads/library/bunny_debug_helpers.sh
+++ b/payloads/library/bunny_debug_helpers.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+################################################################################
+# Allow Debugging messages written to: "/root/udisk/debug/debug.txt"
+# on the BashBunny
+#
+# How this works?
+# 1) Once the lobrary is included in your payload, write text to
+#    the debug file with:
+#       echo "DEBUG MESSAGE" >> "${DEBUG_FILE}"
+#	    OR
+#	    debug_log "DEBUG MESSAGE"
+#	    (To write to log with timestamps)
+# 2) After attack, Text can be read at: "/root/udisk/debug/debug.txt"
+#    on the BashBunny
+# 3) To turn off debugging, pass the OFF comand when including the helper
+#       source bunny_debug_helpers.sh OFF
+################################################################################
+
+################################################################################
+# Start Debug
+################################################################################
+if [ "$1" = "OFF" ]; then
+    DEBUG_STATE="OFF"
+else
+    DEBUG_STATE="ON"
+fi
+
+timestamp () {
+    echo "$(date +"%Y-%m-%d_%H-%M-%S"):"
+}
+
+start_debug () {
+        DEBUG_FILE="./debug/debug.txt"
+    if [ ! -d "./debug" ]; then
+      mkdir ./debug
+    fi
+    touch "${DEBUG_FILE}"
+    echo $(timestamp) "DEBUG STARTED" >> "${DEBUG_FILE}"
+}
+
+debug_log () {
+    echo $(timestamp) "${1}" >> "${DEBUG_FILE}"
+}
+
+
+if [ "${DEBUG_STATE}" = "ON" ]; then
+    start_debug
+else
+    DEBUG_FILE="/dev/null/"
+fi
+
+export DEBUG_FILE

--- a/payloads/library/bunny_debug_helpers.sh
+++ b/payloads/library/bunny_debug_helpers.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
 
 ################################################################################
-# Allow Debugging messages written to: "payload/[switch]/debug/debug_[timestamp].txt"
+# Allow Debugging messages written to: "/root/udisk/debug/debug_[timestamp].txt"
 # on the BashBunny
 #
 # How this works?
-# 1) Once the lobrary is included in your payload, write text to
+# 1) Once the library is included in your payload, write text to
 #    the debug file with:
 #       echo "DEBUG MESSAGE" >> "${DEBUG_FILE}"
 #	    OR
 #	    debug_log "DEBUG MESSAGE"
 #	    (To write to log with timestamps)
-# 2) After attack, Text can be read at: "payload/[switch]/debug/debug_[timestamp].txt"
+# 2) After attack, Text can be read at: "/root/udisk/debug/debug_[timestamp].txt"
 #    on the BashBunny
-# 3) To turn off debugging, pass the OFF comand when including the helper
+# 3) To turn off debugging, pass the OFF command when including the helper
 #       source bunny_debug_helpers.sh OFF
 ################################################################################
 
@@ -31,9 +31,9 @@ timestamp () {
 }
 
 start_debug () {
-    DEBUG_FILE="./debug/debug_$(timestamp).txt"
-    if [ ! -d "./debug" ]; then
-      mkdir ./debug
+    DEBUG_FILE="/root/udisk/debug/debug_$(timestamp).txt"
+    if [ ! -d "/root/udisk/debug/" ]; then
+      mkdir /root/udisk/debug/
     fi
     touch "${DEBUG_FILE}"
     echo "$(timestamp): DEBUG STARTED" >> "${DEBUG_FILE}"

--- a/payloads/library/bunny_debug_helpers.sh
+++ b/payloads/library/bunny_debug_helpers.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ################################################################################
-# Allow Debugging messages written to: "/root/udisk/debug/debug.txt"
+# Allow Debugging messages written to: "/root/udisk/debug/debug_[timestamp].txt"
 # on the BashBunny
 #
 # How this works?
@@ -11,7 +11,7 @@
 #	    OR
 #	    debug_log "DEBUG MESSAGE"
 #	    (To write to log with timestamps)
-# 2) After attack, Text can be read at: "/root/udisk/debug/debug.txt"
+# 2) After attack, Text can be read at: "/root/udisk/debug/debug_[timestamp].txt"
 #    on the BashBunny
 # 3) To turn off debugging, pass the OFF comand when including the helper
 #       source bunny_debug_helpers.sh OFF
@@ -27,22 +27,21 @@ else
 fi
 
 timestamp () {
-    echo "$(date +"%Y-%m-%d_%H-%M-%S"):"
+    echo "$(date +"%Y-%m-%d_%H-%M-%S")"
 }
 
 start_debug () {
-        DEBUG_FILE="./debug/debug.txt"
+    DEBUG_FILE="./debug/debug_$(timestamp).txt"
     if [ ! -d "./debug" ]; then
       mkdir ./debug
     fi
     touch "${DEBUG_FILE}"
-    echo $(timestamp) "DEBUG STARTED" >> "${DEBUG_FILE}"
+    echo "$(timestamp): DEBUG STARTED" >> "${DEBUG_FILE}"
 }
 
 debug_log () {
-    echo $(timestamp) "${1}" >> "${DEBUG_FILE}"
+    echo "$(timestamp): ${1}" >> "${DEBUG_FILE}"
 }
-
 
 if [ "${DEBUG_STATE}" = "ON" ]; then
     start_debug

--- a/payloads/library/bunny_debug_helpers.sh
+++ b/payloads/library/bunny_debug_helpers.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ################################################################################
-# Allow Debugging messages written to: "/root/udisk/debug/debug_[timestamp].txt"
+# Allow Debugging messages written to: "/root/udisk/[payload]/debug/debug_[timestamp].txt"
 # on the BashBunny
 #
 # How this works?
@@ -11,7 +11,7 @@
 #	    OR
 #	    debug_log "DEBUG MESSAGE"
 #	    (To write to log with timestamps)
-# 2) After attack, Text can be read at: "/root/udisk/debug/debug_[timestamp].txt"
+# 2) After attack, Text can be read at: "/root/udisk/[payload]/debug/debug_[timestamp].txt"
 #    on the BashBunny
 # 3) To turn off debugging, pass the OFF comand when including the helper
 #       source bunny_debug_helpers.sh OFF


### PR DESCRIPTION
These helpers allow you to write to a debug file on the BashBunny using either:

debug_log "DEBUG MESSAGE"
(With timestamps)

OR

echo "DEBUG MESSAGE" >> "${DEBUG_FILE}"
(Without timestamps)