### PR TITLE
Added some extra comments regarding the "-"

### DIFF
--- a/library/extensions/setkb.sh
+++ b/library/extensions/setkb.sh
@@ -8,6 +8,7 @@
 # SETKB START (set the keyboard layout to a US keyboard layout)
 # SETKB DONE (set the keyboard layout to the default keyboard determined by the OS language settings)
 # SETKB xx-XX (overwrite the keyboard layout to whatever keyboard layout you need, you will need the [lanugage].json file to run Ducky scripts) 
+# One caveat is that the "-" keycode has to be set to the appropriate key code. Not an issue for most might be an issue for some.
 
 
 function SETKB() {

--- a/library/extensions/setkb.sh
+++ b/library/extensions/setkb.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# SETKB v1 by @elkentaro
+# Simplifies executing commands from HID attacks for different language keyboards. on Windows by using Powershell.
+# Usage: SETKB en-US [give the command the 2 letter combination of keyboard settings]
+#
+# Examples:
+# SETKB en-US (set the keyboard layout to a US keyboard layout)
+# SETKB ja-JP (set the keyboard layout to a Japanese 106 layout)
+
+
+function SETKB() {
+   local kb=$1
+   shift
+   
+   [[ -z "$kb" ]] && exit 1 # KB keyboard parameter must be given.
+   
+   case "$kb" in
+      'en-US')
+         QUACK GUI r
+         QUACK DELAY 500
+         QUACK STRING "powershell.exe Set-WinUserLanguageList -LanguageList en-US -force"
+         QUACK ENTER
+         QUACK DELAY 1500
+
+         ;;
+      *)
+         QUACK GUI r
+         QUACK DELAY 500
+         QUACK "STRING powershell.exe Set-WinUserLanguageList -LanguageList $kb -force"
+         QUACK ENTER
+         QUACK DELAY 1500
+
+         ;;       
+   esac
+}
+
+export -f SETKB

--- a/library/extensions/setkb.sh
+++ b/library/extensions/setkb.sh
@@ -1,37 +1,50 @@
 #!/bin/bash
 #
-# SETKB v1 by @elkentaro
+# SETKB v2.0 by @elkentaro
 # Simplifies executing commands from HID attacks for different language keyboards. on Windows by using Powershell.
 # Usage: SETKB en-US [give the command the 2 letter combination of keyboard settings]
 #
 # Examples:
-# SETKB en-US (set the keyboard layout to a US keyboard layout)
-# SETKB ja-JP (set the keyboard layout to a Japanese 106 layout)
+# SETKB START (set the keyboard layout to a US keyboard layout)
+# SETKB DONE (set the keyboard layout to the default keyboard determined by the OS language settings)
+# SETKB xx-XX (overwrite the keyboard layout to whatever keyboard layout you need, you will need the [lanugage].json file to run Ducky scripts) 
 
 
 function SETKB() {
-   local kb=$1
+   local state=$1
    shift
    
-   [[ -z "$kb" ]] && exit 1 # KB keyboard parameter must be given.
+   [[ -z "$state" ]] && exit 1 # state keyboard parameter must be given.
    
-   case "$kb" in
-      'en-US')
+   case "$state" in
+      'START')
          QUACK GUI r
          QUACK DELAY 500
-         QUACK STRING "powershell.exe Set-WinUserLanguageList -LanguageList en-US -force"
+         QUACK STRING "powershell.exe Set-WinUserLanguageList -LanguageList en-US -force;"
          QUACK ENTER
          QUACK DELAY 1500
 
          ;;
-      *)
+      'DONE')
          QUACK GUI r
          QUACK DELAY 500
-         QUACK "STRING powershell.exe Set-WinUserLanguageList -LanguageList $kb -force"
+         QUACK "STRING powershell.exe \$back2kb=(get-Culture | Select -ExpandProperty Name) ; Set-WinUserLanguageList -LanguageList \$back2kb -force; "
          QUACK ENTER
          QUACK DELAY 1500
 
-         ;;       
+         ;;    
+         
+      *)
+         QUACK GUI r
+         QUACK DELAY 500
+         QUACK "STRING powershell.exe Set-WinUserLanguageList -LanguageList $state -force"
+         QUACK ENTER
+         QUACK DELAY 1500
+
+         ;;    
+
+
+
    esac
 }
 

--- a/library/extensions/setkb.sh
+++ b/library/extensions/setkb.sh
@@ -9,7 +9,8 @@
 # SETKB DONE (set the keyboard layout to the default keyboard determined by the OS language settings)
 # SETKB xx-XX (overwrite the keyboard layout to whatever keyboard layout you need, you will need the [lanugage].json file to run Ducky scripts) 
 # One caveat is that the "-" keycode has to be set to the appropriate key code. Not an issue for most might be an issue for some.
-
+# The simplist way to counter this is to edit the us.json file and change the keycode for "-" to "00:00:56" which is the keypad "-"  
+# this will work even if your original keyboard doesnt have a numpad.
 
 function SETKB() {
    local state=$1

--- a/library/extensions/setkb.sh
+++ b/library/extensions/setkb.sh
@@ -9,7 +9,7 @@
 # SETKB DONE (set the keyboard layout to the default keyboard determined by the OS language settings)
 # SETKB xx-XX (overwrite the keyboard layout to whatever keyboard layout you need, you will need the [lanugage].json file to run Ducky scripts) 
 # One caveat is that the "-" keycode has to be set to the appropriate key code. Not an issue for most might be an issue for some.
-# The simplist way to counter this is to edit the us.json file and change the keycode for "-" to "00:00:56" which is the keypad "-"  
+# The simplest way to counter problem this is to edit the us.json file and change the keycode for "-" to "00:00:56" which is the keypad "-"  
 # this will work even if your original keyboard doesnt have a numpad.
 
 function SETKB() {


### PR DESCRIPTION
Since the extension relies on "-" to have the same key code as an en-US layout, I added some comments regarding this.