### PR TITLE
Edited setkb.sh to restore to Windows System-Locale

### DIFF
--- a/payloads/extensions/setkb.sh
+++ b/payloads/extensions/setkb.sh
@@ -28,7 +28,7 @@ function SETKB() {
       'DONE')
          QUACK GUI r
          QUACK DELAY 500
-         QUACK "STRING powershell.exe \$back2kb=(get-Culture | Select -ExpandProperty Name) ; Set-WinUserLanguageList -LanguageList \$back2kb -force; "
+         QUACK "STRING powershell.exe \$sl=(Get-WinSystemLocale | Select -ExpandProperty Name) ; Set-WinUserLanguageList -LanguageList \$sl -force; "
          QUACK ENTER
          QUACK DELAY 1500
 


### PR DESCRIPTION
the existing `get-Culture | Select -ExpandProperty Name` in `SETKB DONE` returned en-GB by default,
changed to `Get-WinSystemLocale | Select -ExpandProperty Name` to restore to the System Locale set by the Windows User