### PR TITLE
Fixed errors in public IP address command

### DIFF
--- a/payloads/library/recon/InfoGrabber/info.ps1
+++ b/payloads/library/recon/InfoGrabber/info.ps1
@@ -2,7 +2,15 @@
 # Simen Kjeserud (Original creator), Gachnang
 
 #Get info about pc
-$computerPubIP=(Invoke-WebRequest ipinfo.io/ip).Content
+
+try
+{
+$computerPubIP=(Invoke-WebRequest ipinfo.io/ip -UseBasicParsing).Content
+}
+catch
+{
+$computerPubIP="Error getting Public IP"
+}
 $computerIP = get-WmiObject Win32_NetworkAdapterConfiguration|Where {$_.Ipaddress.length -gt 1}
 $IsDHCPEnabled = $false
 $Networks =  Get-WmiObject Win32_NetworkAdapterConfiguration -Filter "DHCPEnabled=$True" | ? {$_.IPEnabled}
@@ -171,9 +179,9 @@ $computerSystem.Name
 
 "Network: "
 "=================================================================="
-"Computers MAC adress: " + $computerMAC
-"Computers IP adress: " + $computerIP.ipaddress[0] 
-"Public IP adress: " + $computerPubIP  
+"Computers MAC address: " + $computerMAC
+"Computers IP address: " + $computerIP.ipaddress[0] 
+"Public IP address: " + $computerPubIP  
 "RDP: " + $RDP
 ""
 ($Network| out-string)


### PR DESCRIPTION
When no Internet connection is available the command runs into an error:
"The remote name could not be resolved: 'ipinfo.io'"
Fixed this with a try and catch block

The command also runs into an error when Internet Explorer was never started.
"Invoke-WebRequest : The response content cannot be parsed because the Internet Explorer engine is not available, or Internet Explorer's first-launch configuration is not complete. Specify the
UseBasicParsing parameter and try again"
Fixed this with the -UseBasicParsing parameter