### PR TITLE
Added i3-wm compatability

### DIFF
--- a/payloads/extensions/run.sh
+++ b/payloads/extensions/run.sh
@@ -37,6 +37,20 @@ function RUN() {
          QUACK DELAY 500
          QUACK ENTER
          ;;
+      i3-Win)
+         QUACK GUI ENTER
+         QUACK DELAY 500
+         QUACK STRING "$@"
+         QUACK DELAY 500
+         QUACK ENTER
+         ;;
+      i3-Alt)
+         QUACK ALT ENTER
+         QUACK DELAY 500
+         QUACK STRING "$@"
+         QUACK DELAY 500
+         QUACK ENTER
+         ;;
       *)
          # OS parameter must be one of the above
          exit 1


### PR DESCRIPTION
i3 : https://i3wm.org/
Uses the two main/default keybinds. This is more for people who use Arch Linux as most use i3.(Not all)
There is another possible attack vector for i3 that doesn't rely on the use using the enter key as there default terminal "shortcut" but instead uses the D key that is used as like a run box (dmenu : https://wiki.archlinux.org/index.php/dmenu) and ensures it uses any installed terminal emulator as i3 has a nifty program aptly named "i3-sensible-terminal", but to implement that relies on the user both having dmenu and using one of the default/suggested keybinds.