### PR TITLE
BlueTeamPCAudit

### DIFF
--- a/payloads/library/general/BlueTeamPCAudit/1.ps1
+++ b/payloads/library/general/BlueTeamPCAudit/1.ps1
@@ -1,0 +1,72 @@
+﻿#CHANGE VARIABLES BELOW
+#* Author: Sorsnce
+#* Version: Version 1.0
+#* Target: Windows 10
+#
+#Gets the current logged in username
+$user = $(Get-WMIObject -class Win32_ComputerSystem | select username).username
+#Varaiable you need to change for the script to work.#
+######################################################
+#Set the following email address you want to send the email too.
+$To = "SecurityTeam@yahoo.com"
+
+#Set to the SMTP server for your organization EXAMPLE: smtpserver = "smtp.yahoo.local"
+$smtpserver = "smtp.yahoo.local"
+
+#The following trims off the domain in front of the username
+#EXAMPLE: $User = Yahoo\John.Smith --> $username = John.Smith
+$username = $user.Substring(6)
+
+#Change $username+"" to your email EXAMPLE: $email = $username+"@yahoo.com"
+$email = $username+"@yahoo.com"
+######################################################
+#Gets drive letter for the bashbunny                 #
+$drive = (Get-WMIObject Win32_Volume | ? { $_.Label -eq 'bashbunny' }).name
+
+#Sets variable  to drive plus the file location
+$Test = $drive + "payloads\switch1\background.bmp"
+
+#Sets variable to test the path to file (background.bmp)
+$Switch1 = Test-Path $Test
+
+#Finds what switch bashbunny is set too
+if ($Switch1 -eq "True") {$Path = $drive + "payloads\switch1\background.bmp"}
+else {$Path = $drive + "payloads\switch2\background.bmp"}
+
+#Sets wallpaper to background.bmp
+$setwallpapersrc = @"
+using System.Runtime.InteropServices;
+public class wallpaper
+{
+public const int SetDesktopWallpaper = 20;
+public const int UpdateIniFile = 0x01;
+public const int SendWinIniChange = 0x02;
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+private static extern int SystemParametersInfo (int uAction, int uParam, string lpvParam, int fuWinIni);
+public static void SetWallpaper ( string path )
+{
+SystemParametersInfo( SetDesktopWallpaper, 0, path, UpdateIniFile | SendWinIniChange );
+}
+}
+"@
+Add-Type -TypeDefinition $setwallpapersrc
+[wallpaper]::SetWallpaper($path) 
+#This sets the subject for the email
+$subject = "PC Unlocked for $user"
+#This sets the BODY for the email, currently using HTML
+$body=@"
+<body>
+Security Violation!
+<p>
+$user left his or hers PC Unlocked!<br/>
+<p>
+</p>
+<p>Thanks,</p>
+<p></p>
+Cyber Security
+<p></p>
+<p>Sent from my bashbunny.</p>
+</body>
+"@
+#This sends the email with the attributes described above
+send-mailmessage -smtpserver $smtpserver -to $To -Subject $subject -from $email -body $body -BodyAsHtml

--- a/payloads/library/general/BlueTeamPCAudit/payload.txt
+++ b/payloads/library/general/BlueTeamPCAudit/payload.txt
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# Title:         Blue Team PC Audit
+# Author:        Sorsnce	
+# Version:       1.0
+# Target:        Windows
+# 
+#The PowerShell script changes the users background to "background.bmp", this allows Blue team to remind users to lock their PCs.
+#The PowerShell script also sends an email to the Security Team with information about the users PC.
+#This allows the Security Team to keep a record of repeatable offenders.
+
+#Executes 1.ps1
+
+# Source bunny_helpers.sh to get environment variable SWITCH_POSITION
+source bunny_helpers.sh
+LED SETUP
+ATTACKMODE HID STORAGE
+LED ATTACK
+Q  GUI r
+Q  DELAY 1000
+Q  STRING powershell -windowstyle hidden ".((gwmi win32_volume -f 'label=''BashBunny''').Name+'payloads\\$SWITCH_POSITION\1.ps1')"
+Q  ENTER
+LED FINISH

--- a/payloads/library/general/BlueTeamPCAudit/readme.md
+++ b/payloads/library/general/BlueTeamPCAudit/readme.md
@@ -12,7 +12,10 @@ This allows the Security Team to keep a record of repeatable offenders.
 
 ## Configuration
 
-Edit 1.ps1 to specify usernames, email addresses, domain.
+Edit 1.ps1 to specify usernames, email addresses, and domain.
+You will need to add your background iamge with the name of "background.bmp". This file will be the new background on the PC.
+The script will accept other file formats as long as you change the file extension in the powershell script. 
+Place "background.bmp" in the same directory as your payload, and you should be ready to use the Blue Team PC Audit script.
 
 ## STATUS
 

--- a/payloads/library/general/BlueTeamPCAudit/readme.md
+++ b/payloads/library/general/BlueTeamPCAudit/readme.md
@@ -1,0 +1,26 @@
+# Blue Team PC Audit
+
+* Author: Sorsnce
+* Version: Version 1.0
+* Target: Windows
+
+## Description
+
+The PowerShell script changes the users background to "background.bmp", this allows Blue team to remind users to lock their PCs.
+The PowerShell script also sends an email to the Security Team with information about the users PC.
+This allows the Security Team to keep a record of repeatable offenders.
+
+## Configuration
+
+Edit 1.ps1 to specify usernames, email addresses, domain.
+
+## STATUS
+
+| LED                | Status                                       |
+| ------------------ | -------------------------------------------- |
+| Magenta			 | Setup								        |
+| Yellow		     | Calling the Powershell Script                |
+| Green              | Attack Complete                              |
+
+## Discussion
+


### PR DESCRIPTION
The PowerShell script changes the user's background to "background.bmp", this allows Blue team to remind users to lock their PCs.
The PowerShell script also sends an email to the Security Team with information about the users PC.
This allows the Security Team to keep a record of repeatable offenders.