### PR TITLE
[FIX] mac_happy extension

### DIFF
--- a/payloads/extensions/mac_happy.sh
+++ b/payloads/extensions/mac_happy.sh
@@ -1,26 +1,16 @@
 #!/bin/bash
 
-#Title:     Mac_Happy
+# Title:     Mac_Happy
 # Author:    thehappydinoa
 # Target:    Mac
-# Version:   0.1
+# Version:   0.2
 #
 # Makes Mac happy by correctly setting pid and vid
 # Use by running mac_happy ATTACKMODE HID <attack modes here>
 #
 
-function mac_happy() {
-    [[ -z "$1" ]] && exit 1 # parameter must be set
-
-    [[ ! $1 =~ "ATTACKMODE" ]] && exit 1 # parameter must be for ATTACKMODE
-
-    for i in $*;
-    do
-        command=$(echo $command $i)
-    done
-
-    command=$(echo $command VID_0X05AC PID_0X021E)
-
-    eval $command
+function MAC_HAPPY() {
+    [[ "$#" -gt 1 && "$1" == "ATTACKMODE" ]] || exit 1
+    eval "$@ vid_0x05ac pid_0x021e"
 }
-export -f mac_happy
+export -f MAC_HAPPY


### PR DESCRIPTION
 - fixes state leakage of `command` variable by removing it 
 - remove unecessary use of forked processes/sub-commands
 - combine input validation conditionals
 - match the standard of existing extensions of exporting function
   names as all caps
 - bump version number