### PR TITLE
Adding Delay to Prank/Startup-Message

### DIFF
--- a/payloads/library/prank/Startup-Message/payload.txt
+++ b/payloads/library/prank/Startup-Message/payload.txt
@@ -16,6 +16,7 @@ LED ATTACK
 
 #Running cmd to create file in startup directory
 RUN WIN cmd
+Q DELAY 150
 Q STRING "cd C:\Users\%USERNAME%\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup"
 Q ENTER
 Q STRING "echo @echo off > startup.bat"


### PR DESCRIPTION
You must add a delay after RUN WIN cmd or it won't always write on the cmd