### PR TITLE
Fix for zsh

### DIFF
--- a/payloads/library/prank/UnifiedRickRoll/payload.txt
+++ b/payloads/library/prank/UnifiedRickRoll/payload.txt
@@ -13,7 +13,7 @@ Q DELAY 1000
 Q GUI n
 Q DELAY 1000
 
-Q STRING hi=0\; ho=\$\(date \'+%H%M\'\)\; while test \$hi == \'0\'\;  do    if [ \$ho == $time ]\;    then osascript -e \"set Volume 9\" \&\& open \"https://www.youtube.com/watch?v=dQw4w9WgXcQ\" \;    hi=1\;    fi\;    ho=\$\(date \'+%H%M\'\)\; sleep 1\; done \& disown
+Q STRING hi=0\; ho=\$\(date \'+%H%M\'\)\; while [ \$hi = \'0\' ]\;  do    if [ \$ho = $time ]\;    then osascript -e \"set Volume 9\" \&\& open \"https://www.youtube.com/watch?v=dQw4w9WgXcQ\" \;    hi=1\;    fi\;    ho=\$\(date \'+%H%M\'\)\; sleep 1\; done \& disown
 
 # close up shop
 Q DELAY 1000


### PR DESCRIPTION
While comparison = and == are identical on bash (refer http://www.tldp.org/LDP/abs/html/comparison-ops.html ), double equals behave differently on zsh (refer https://unix.stackexchange.com/questions/255480/why-does-behave-differently-inside-in-zsh-and-bash ). Single = is also equally POSIX compliant.

Co-Authored-By: Minh Thien Nhat Nguyen <nhat286@users.noreply.github.com>