### PR TITLE
New WAITEJECT Extension

### DIFF
--- a/payloads/extensions/waiteject.sh
+++ b/payloads/extensions/waiteject.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# WAITEJECT v1 by kamotswind (https://github.com/kamotswind)
+# Blocks the payload from continuing until the USB storage is ejected from the host
+# Usage: WAITEJECT
+
+function WAITEJECT() {
+	until [ ! -z "`dmesg | grep \"usb close backing file\"`" ]
+	do
+		sleep 1
+	done
+}
+
+export -f WAITEJECT


### PR DESCRIPTION
This simple extension monitors the output of dmesg for the phrase "usb close backing file" which is what is logged when the USB storage is ejected by the OS. Tested on Linux and Windows hosts with Bash Bunny firmware version 1.5_298.

I needed this for a payload I am writing and decided to share it with the community before I finish the payload.

It may be a better idea to modify the existing WAIT function with WAIT SWITCH and WAIT EJECT. Thoughts?