### PR TITLE
Chromeos Enrollment

### DIFF
--- a/payloads/library/general/ChromeOSDeployment/Readme.md
+++ b/payloads/library/general/ChromeOSDeployment/Readme.md
@@ -9,6 +9,9 @@ Version: Version 2
 This is the enterprise enrolment process for ChromeOS.
 I use this code at work when we get a bulk order in, but i have added more options so i can be used by anyone.
 
+Set the following variables in the payload for your network. only select one wifi type or it will use WPA by default
+and dont forget those backslashes if you use symbols in the strings.
+
 Set the DUCKY_LANG to the correct keyboard to avoid credential mistypes
 ## Variables
 | Vars              | Notes                                                                        |
@@ -34,12 +37,12 @@ Set the DUCKY_LANG to the correct keyboard to avoid credential mistypes
 | EwDEFAULT | Do not change this; it is used to check that only one wifi type is set to 'y' else use EwWPA |
 | - | - |
 | AuthMethod | This defines what you want to use as authentication when using enterprise wifi, set one of the following numbers |
-| 0 | auto |
-| 1 | EAP-MDS |
-| 2 or 3 | MSCHAP  or MSCHAPv2 |
-| 4 | PAP |
-| 5 | CHAP |
-| 6 | GTC |
+| 0 | auto - PEAP and EAP|
+| 1 | EAP-MDS  - PEAP and EAP |
+| 2 or 3 | MSCHAP  or MSCHAPv2  - PEAP and EAP |
+| 4 | PAP  - EAP|
+| 5 | CHAP  - EAP |
+| 6 | GTC   - EAP|
 
 
 ## STATUS

--- a/payloads/library/general/ChromeOSDeployment/Readme.md
+++ b/payloads/library/general/ChromeOSDeployment/Readme.md
@@ -15,17 +15,33 @@ Set the DUCKY_LANG to the correct keyboard to avoid credential mistypes
 ## Variables
 | Vars              | Notes                                                                        |
 | ---------------- | ----------------------------------------------------------------------------- |
-| ChromePre70        | if the OS is pre 70 then there is a slight variation in key presses so set correctly {y/n}|
+| WIFI_NAME        | WIFI SSID {string}|
 | WIFI_USER    | Wifi username : This is used if enterprise wifi type is selected {string}|
 | WIFI_PASS    | Wifi password : used on all wireless connection types {string}|
+| WIFI_ANNON | Wifi annonymous id : can be used on enterprise auth {string}|
 | ENROL_USER | This is the user account used for device enrolment {string}|
 | ENROL_PASS | The password for ENROL_USER {string}|
+| - | - |
+| WIFI TYPES | Only one of these should be set to y |
+| EwWEP | WIFI type: WEP {y/n}|
 | EwWPA | WIFI type: WPA {y/n}|
 | EwPEAP | WIFI type: PEAP {y/n}|
 | EwLEAP | WIFI type: LEAP {y/n}|
+| EwEAP | WIFI type: EAP {y/n} |
+| - | - |
 | checkCERT | Check or ignore WIFI certificate {y/n}|
+| SaveWIFI | Set to save wifi connection. isnt needed if enrolment forces a wifi connection {y/n}|
 | sendGoogleData | Send analytic data to google... unsure why you would want to but the option is here {y/n} |
+| WaitForUpdates | Can wait for updates to complete then flick switch to continue or wait 10secs for the update check then move on {y/n} |
 | EwDEFAULT | Do not change this; it is used to check that only one wifi type is set to 'y' else use EwWPA |
+| - | - |
+| AuthMethod | This defines what you want to use as authentication when using enterprise wifi, set one of the following numbers |
+| 0 | auto |
+| 1 | EAP-MDS |
+| 2 or 3 | MSCHAP  or MSCHAPv2 |
+| 4 | PAP |
+| 5 | CHAP |
+| 6 | GTC |
 
 
 ## STATUS

--- a/payloads/library/general/ChromeOSDeployment/Readme.md
+++ b/payloads/library/general/ChromeOSDeployment/Readme.md
@@ -1,0 +1,38 @@
+ChromeOS Deployment For Bash Bunny
+
+Author: TheDragonkeeper
+
+Version: Version 1
+
+## Description
+
+This is the enterprise enrolment process for ChromeOS.
+I use this code at work when we get a bulk order in.
+
+WIP im still merging my different payloads into one.
+
+Set the DUCKY_LANG to the correct keyboard to avoid credential mistypes
+## Variables
+| Vars              | Notes                                                                        |
+| ---------------- | ----------------------------------------------------------------------------- |
+| ChromePre70        | if the OS is pre 70 then there is a slight variation in key presses so set correctly {y/n}|
+| WIFI_USER    | Wifi username : This is used if enterprise wifi type is selected {string}|
+| WIFI_PASS    | Wifi password : used on all wireless connection types {string}|
+| ENROL_USER | This is the user account used for device enrolment {string}|
+| ENROL_PASS | The password for ENROL_USER {string}|
+| EwWPA | WIFI type: WPA {y/n}|
+| EwPEAP | WIFI type: PEAP {y/n}|
+| EwLEAP | WIFI type: LEAP {y/n}|
+| checkCERT | Check or ignore WIFI certificate {y/n}|
+| sendGoogleData | Send analytic data to google... unsure why you would want to but the option is here {y/n} |
+| EwDEFAULT | Do not change this; it is used to check that only one wifi type is set to 'y' else use EwWPA |
+
+
+## STATUS
+
+| LED              | Status                                                                        |
+| ---------------- | ----------------------------------------------------------------------------- |
+| Blue slow        | Booting                                                                       |
+| Red              | Executing                                                                     |
+| Green flashing   | Waiting for switch change to continue, used in case any updates are avalible  |
+| Green            | Task complete, ready to unplug                                                |

--- a/payloads/library/general/ChromeOSDeployment/Readme.md
+++ b/payloads/library/general/ChromeOSDeployment/Readme.md
@@ -2,14 +2,12 @@ ChromeOS Deployment For Bash Bunny
 
 Author: TheDragonkeeper
 
-Version: Version 1
+Version: Version 2
 
 ## Description
 
 This is the enterprise enrolment process for ChromeOS.
-I use this code at work when we get a bulk order in.
-
-WIP im still merging my different payloads into one.
+I use this code at work when we get a bulk order in, but i have added more options so i can be used by anyone.
 
 Set the DUCKY_LANG to the correct keyboard to avoid credential mistypes
 ## Variables

--- a/payloads/library/general/ChromeOSDeployment/payload.txt
+++ b/payloads/library/general/ChromeOSDeployment/payload.txt
@@ -4,32 +4,42 @@ LED R 0
 # set your keyboard !!
 DUCKY_LANG gb
 
-## add keys for pre 70
-ChromePre70='n'
-
+## wifi ssid
 WIFI_NAME="xxx"
 ##wifi creds
 WIFI_USER="xxx" #only used on enterprise
 WIFI_PASS="xxx"
+## wifi annonymous ID
+WIFI_ANNON=''
 #creds to enrol device
 ENROL_USER="xxx"
 ENROL_PASS="xxx"
 
 # change
+EwWEP='n'
 EwWPA='n'
 EwPEAP='n'
 EwLEAP='n'
+EwEAP='n'
 
-
-## ent wifi options
+##Authentication method
+# 0: auto  1: EAP_MDS 2: MSCHAP 3: MSCHAPv2
+# 4: PAP  5: CHAP  6: GTC
+AuthMethod=0
+##check wifi cert
 checkCERT='n'
+##save wifi creds
+SaveWIFI='y'
+# send data to google
 sendGoogleData='n'
+#wait on device updates
+WaitForUpdates='y'
 
 
 
 ##defaults to WPA if more than one wifi type set as 'y'
 EwDEFAULT='n'
-options=($EwWPA $EwPEAP $EwLEAP);
+options=($EwWPA $EwPEAP $EwLEAP $EwEAP $EwWEP);
 options=(${options[@]/n/})
 [[ ${#options[@]} -gt 1 ]] && $EwDEFAULT='y'
 
@@ -68,14 +78,17 @@ keys "TAB" 3
 keys "ENTER"
 
 ##ssid
-sleep 3
+sleep 2
 QUACK STRING $WIFI_NAME
 sleep 1
 keys "TAB"
 
-## wpa
-if [ $EwDEFAULT == 'y' ] || [ $EwWPA == 'y' ]; then
-    keys "DOWNARROW" 2
+
+#wifi security
+## wpa or wep
+if [ $EwDEFAULT == 'y' ] || [[ $EwWPA == 'y' || $EwWEP == 'y' ]]; then
+    [[ $EwWEP == 'y' ]] && keys "DOWNARROW"
+    [[ $EwWPA == 'y' ]] && keys "DOWNARROW" 2
     keys "TAB"
     QUACK STRING $WIFI_PASS
     sleep 1
@@ -84,28 +97,42 @@ if [ $EwDEFAULT == 'y' ] || [ $EwWPA == 'y' ]; then
 fi
 
 ## enterprise with PEAP
-if [ $EwDEFAULT == 'n' ] && [[ $EwPEAP == 'y' || $EwLEAP == 'y' ]]; then
-    keys "DOWNARROW" 3
+if [ $EwDEFAULT == 'n' ] && [[ $EwPEAP == 'y' || $EwLEAP == 'y' || $EwEAP == 'y' ]]; then
+    [[ $EwPEAP == 'y' ]] && keys "DOWNARROW" 1
+    [[ $EwEAP == 'y' ]] && keys "DOWNARROW" 2
     keys "TAB"
-    keys "DOWNARROW"
-    keys "TAB"
-### add in the extra keys for leap
-## add vars for types
-    keys "DOWNARROW" 2
-    keys "TAB"
-    [[ $checkCERT == 'n' ]] && keys "DOWNARROW"
-    keys "TAB"
-    # wifi creds
-    QUACK STRING $WIFI_USER
-    keys "TAB"
-    QUACK STRING $WIFI_PASS
-    sleep 1
-    #save ?
-    keys "TAB" 3
-    keys "ENTER"
-    ##connect ?
-    keys "TAB" 2
-    QUACK ENTER
+    if [ $EwLEAP == 'y' ]; then
+        QUACK STRING $WIFI_USER
+        keys "TAB"
+        QUACK STRING $WIFI_PASS
+        keys "TAB" 2
+        ## check this line, positive keys correct, might not be for save.
+        [[ $SaveWIFI == 'y' ]] && keys "ENTER"
+        keys "TAB" 2
+        keys "ENTER"
+    else
+
+        if [ $AuthMethod != 0 ]; then
+            if [ $AuthMethod == 3 ] && [ $EwPEAP == 'y' ]; then
+                keys "DOWNARROW" 2
+            else
+                keys "DOWNARROW" $AuthMethod
+            fi
+        fi
+        keys "TAB"
+        [[ $checkCERT == 'n' ]] && keys "DOWNARROW"
+        keys "TAB"
+        # wifi creds
+        QUACK STRING $WIFI_USER
+        keys "TAB"
+        QUACK STRING $WIFI_PASS
+        keys "TAB" 2
+        [[ $WIFI_ANNON != '' ]] && QUACK STRING $WIFI_ANNON
+        keys "TAB"
+        [[ $SaveWIFI == 'y' ]] && keys "ENTER"
+        keys "TAB" 2
+        QUACK ENTER
+    fi
 fi
 
 ## waiting for wifi connection
@@ -115,33 +142,35 @@ sleep 25
 ## main screen starting on Lang button
 keys "TAB" 2
 keys "ENTER"
-
-# check if need two more tabs?
-
 keys "TAB" 3
 keys "ENTER"
+#waitng on screen change
 sleep 2
-
 ##enter TOS
-
 keys "TAB" 2
 [[ $sendGoogleData == 'n' ]] && keys "ENTER"
-sleep 2
 keys "TAB" 3
 QUACK ENTER
 ### waiting on device
 ## could be performing updates so will wait for this to finish
-## and continue by moving the switch
-LED G FAST
-WAIT
-LED R 0
+## and continue by moving the switch or by waiting 10 seconds while it does checks
+if [ $WaitForUpdates == 'y' ];then
+    LED G FAST
+    WAIT
+    LED R 0
+else
+    sleep 10
+fi
 ##########################  enrollment
+QUACK ALT-CTRL e
+## if not previously enrolled, wont show this screen so force it
+sleep 2
 QUACK STRING $ENROL_USER
-sleep 1
 keys "ENTER"
+## wait for screen swap
+sleep 2
 ## enroll pass
 QUACK STRING $ENROL_PASS
-sleep 1
 QUACK ENTER
 
 ## green light, finished, waiting for user to input asset info

--- a/payloads/library/general/ChromeOSDeployment/payload.txt
+++ b/payloads/library/general/ChromeOSDeployment/payload.txt
@@ -87,8 +87,12 @@ keys "TAB"
 #wifi security
 ## wpa or wep
 if [ $EwDEFAULT == 'y' ] || [[ $EwWPA == 'y' || $EwWEP == 'y' ]]; then
-    [[ $EwWEP == 'y' ]] && keys "DOWNARROW"
-    [[ $EwWPA == 'y' ]] && keys "DOWNARROW" 2
+    if [ $EwDEFAULT == 'y' ]; then
+        keys "DOWNARROW" 2
+    else
+        [[ $EwWEP == 'y' ]] && keys "DOWNARROW"
+        [[ $EwWPA == 'y' ]] && keys "DOWNARROW" 2
+    fi
     keys "TAB"
     QUACK STRING $WIFI_PASS
     sleep 1

--- a/payloads/library/general/ChromeOSDeployment/payload.txt
+++ b/payloads/library/general/ChromeOSDeployment/payload.txt
@@ -1,0 +1,148 @@
+LED B SLOW
+ATTACKMODE HID
+LED R 0
+# set your keyboard !!
+DUCKY_LANG gb
+
+## add keys for pre 70
+ChromePre70='n'
+
+WIFI_NAME="xxx"
+##wifi creds
+WIFI_USER="xxx" #only used on enterprise
+WIFI_PASS="xxx"
+#creds to enrol device
+ENROL_USER="xxx"
+ENROL_PASS="xxx"
+
+# change
+EwWPA='n'
+EwPEAP='n'
+EwLEAP='n'
+
+
+## ent wifi options
+checkCERT='n'
+sendGoogleData='n'
+
+
+
+##defaults to WPA if more than one wifi type set as 'y'
+EwDEFAULT='n'
+options=($EwWPA $EwPEAP $EwLEAP);
+options=(${options[@]/n/})
+[[ ${#options[@]} -gt 1 ]] && $EwDEFAULT='y'
+
+
+keys () {
+    if [ -z $2 ]; then
+        QUACK $1
+        sleep 1
+    else
+        count=0
+        while [ $count -lt $2 ]; do
+            count=$((count+1))
+            QUACK $1
+            sleep 1
+        done
+    fi
+}
+
+
+## main screen needs to have the language bar hightlighted
+
+# just added this sleep to be sure the OS has had time to accept HID
+# as some devices can be slower
+sleep 5
+
+## open sys tray 
+QUACK ALT-SHIFT s
+sleep 2
+
+#select wifi
+keys "TAB" 4
+keys "ENTER"
+
+## add wifi
+keys "TAB" 3
+keys "ENTER"
+
+##ssid
+sleep 3
+QUACK STRING $WIFI_NAME
+sleep 1
+keys "TAB"
+
+## wpa
+if [ $EwDEFAULT == 'y' ] || [ $EwWPA == 'y' ]; then
+    keys "DOWNARROW" 2
+    keys "TAB"
+    QUACK STRING $WIFI_PASS
+    sleep 1
+    keys "TAB" 3
+    keys "ENTER"
+fi
+
+## enterprise with PEAP
+if [ $EwDEFAULT == 'n' ] && [[ $EwPEAP == 'y' || $EwLEAP == 'y' ]]; then
+    keys "DOWNARROW" 3
+    keys "TAB"
+    keys "DOWNARROW"
+    keys "TAB"
+### add in the extra keys for leap
+## add vars for types
+    keys "DOWNARROW" 2
+    keys "TAB"
+    [[ $checkCERT == 'n' ]] && keys "DOWNARROW"
+    keys "TAB"
+    # wifi creds
+    QUACK STRING $WIFI_USER
+    keys "TAB"
+    QUACK STRING $WIFI_PASS
+    sleep 1
+    #save ?
+    keys "TAB" 3
+    keys "ENTER"
+    ##connect ?
+    keys "TAB" 2
+    QUACK ENTER
+fi
+
+## waiting for wifi connection
+sleep 25
+
+
+## main screen starting on Lang button
+keys "TAB" 2
+keys "ENTER"
+
+# check if need two more tabs?
+
+keys "TAB" 3
+keys "ENTER"
+sleep 2
+
+##enter TOS
+
+keys "TAB" 2
+[[ $sendGoogleData == 'n' ]] && keys "ENTER"
+sleep 2
+keys "TAB" 3
+QUACK ENTER
+### waiting on device
+## could be performing updates so will wait for this to finish
+## and continue by moving the switch
+LED G FAST
+WAIT
+LED R 0
+##########################  enrollment
+QUACK STRING $ENROL_USER
+sleep 1
+keys "ENTER"
+## enroll pass
+QUACK STRING $ENROL_PASS
+sleep 1
+QUACK ENTER
+
+## green light, finished, waiting for user to input asset info
+LED G


### PR DESCRIPTION
This payload is for Chrome OS devices. This is for Version 70 and above.
The use case is to automatically go through the enterprise enrollment process and stop on the last page which lets the user add the unique asset name and asset ID of the device.
