### PR TITLE
Instant OS detection

### DIFF
--- a/payloads/extensions/get.sh
+++ b/payloads/extensions/get.sh
@@ -18,21 +18,23 @@ function GET() {
       export SWITCH_POSITION="invalid"
       ;;
     "TARGET_OS")
-      GET TARGET_IP
-      ScanForOS=$(nmap -Pn -O $TARGET_IP -p1 -v2)
-      [[ $ScanForOS == *"Too many fingerprints"* ]] && ScanForOS=$(nmap -Pn -O $TARGET_IP --osscan-guess -v2)
-      [[ "${ScanForOS,,}" == *"windows"* ]] && export TARGET_OS='WINDOWS' && return
-      [[ "${ScanForOS,,}" == *"apple"* ]] && export TARGET_OS='MACOS' && return
-      [[ "${ScanForOS,,}" == *"linux"* ]] && export TARGET_OS='LINUX' && return
-      export TARGET_OS='UNKNOWN'
-      ;;
-    "TARGET_OS_QUICK")
-      GET TARGET_IP
-      ScanForOS=$(ping -c1 $TARGET_IP)
-      [[ "${ScanForOS,,}" == *"ttl=128"* ]] && export TARGET_OS='WINDOWS' && return
-      [[ "${ScanForOS,,}" == *"ttl=64"* ]] && export TARGET_OS='LINUX' && return
-      [[ "${ScanForOS,,}" == *"ttl=63"* ]] && export TARGET_OS='CHROMEOS' && return
-      export TARGET_OS='UNKNOWN'
+      DATABASE=/root/udisk/payloads/extensions/OSdatabase
+      FINGERPRINT=$(cat /var/log/syslog | grep FINGERPRINT | awk '{ print $9 " " $7 }' | sort -u | awk '{ print $2 }' | awk 'END{print}')
+      [[ -f $DATABASE ]] || touch $DATABASE
+      sed -i $FINGERPRINT > /var/log/syslog
+      if [ -f $DATABASE ] ; then
+          TARGET_OS=$(cat $DATABASE | grep $FINGERPRINT | awk '{ print $2 }')
+          GET TARGET_IP
+          if [ -z $TARGET_OS ]; then
+              ScanForOS=$(nmap -Pn -O $TARGET_IP -p1 -v2)
+              [[ $ScanForOS == *"Too many fingerprints"* ]] && ScanForOS=$(nmap -Pn -O $TARGET_IP --osscan-guess -v2)
+              [[ "${ScanForOS,,}" == *"linux"* ]] && export TARGET_OS='LINUX'
+              [[ "${ScanForOS,,}" == *"apple"* ]] && export TARGET_OS='MACOS'
+              [[ "${ScanForOS,,}" == *"windows"* ]] && export TARGET_OS='WINDOWS'
+              [[ -z $TARGET_OS ]] && export TARGET_OS='UNKNOWN'
+              echo $FINGERPRINT $TARGET_OS >> $DATABASE
+          fi
+      fi
       ;;
   esac
 }

--- a/payloads/extensions/get.sh
+++ b/payloads/extensions/get.sh
@@ -18,12 +18,20 @@ function GET() {
       export SWITCH_POSITION="invalid"
       ;;
     "TARGET_OS")
-      TARGET_IP=$(cat /var/lib/dhcp/dhcpd.leases | grep ^lease | awk '{ print $2 }' | sort | uniq)
+      GET TARGET_IP
       ScanForOS=$(nmap -Pn -O $TARGET_IP -p1 -v2)
       [[ $ScanForOS == *"Too many fingerprints"* ]] && ScanForOS=$(nmap -Pn -O $TARGET_IP --osscan-guess -v2)
       [[ "${ScanForOS,,}" == *"windows"* ]] && export TARGET_OS='WINDOWS' && return
       [[ "${ScanForOS,,}" == *"apple"* ]] && export TARGET_OS='MACOS' && return
       [[ "${ScanForOS,,}" == *"linux"* ]] && export TARGET_OS='LINUX' && return
+      export TARGET_OS='UNKNOWN'
+      ;;
+    "TARGET_OS_QUICK")
+      GET TARGET_IP
+      ScanForOS=$(ping -c1 $TARGET_IP)
+      [[ "${ScanForOS,,}" == *"ttl=128"* ]] && export TARGET_OS='WINDOWS' && return
+      [[ "${ScanForOS,,}" == *"ttl=64"* ]] && export TARGET_OS='LINUX' && return
+      [[ "${ScanForOS,,}" == *"ttl=63"* ]] && export TARGET_OS='CHROMEOS' && return
       export TARGET_OS='UNKNOWN'
       ;;
   esac


### PR DESCRIPTION
As you can see there is a few changes here.
1)  This is using the DHCP server to find the OS that connected to it.

2)  It will auto create, update the database list when connecting to new devices. i placed it in this location so it can be updated by other people.  i wasnt able to find a database to use offline, an online version would take extra steps / require an unlocked machine to share the connection. so this was the next best thing.
This allows us to use the database as a 1st step and if the device is non existent we can fall back on the current TARGET_OS method to fill the database in for us.

3)  I changed the order of assignment for TARGET_OS as it was giving false results, i.e saying a windows machine was linux.

4) change the /etc/dhcp/dhcpd.conf file so that it requests the OS details when connecting - it needs the following at the bottom: 


set dhcp-op-req-string = binary-to-ascii(10,8,":",option dhcp-parameter-request$
log(info,
concat("FINGERPRINT ",
binary-to-ascii(10,8,",",option dhcp-parameter-request-list),
" for ",
concat (
        suffix (concat ("0", binary-to-ascii (16, 8, "",
          substring (hardware, 1, 1))),2), ":",
        suffix (concat ("0", binary-to-ascii (16, 8, "",
          substring (hardware, 2, 1))),2), ":",
        suffix (concat ("0", binary-to-ascii (16, 8, "",
          substring (hardware, 3, 1))),2), ":",
        suffix (concat ("0", binary-to-ascii (16, 8, "",
          substring (hardware, 4, 1))),2), ":",
        suffix (concat ("0", binary-to-ascii (16, 8, "",
          substring (hardware, 5, 1))),2), ":",
        suffix (concat ("0", binary-to-ascii (16, 8, "",
          substring (hardware, 6, 1))),2)
       )
));

subnet 172.16.64.0 netmask 255.255.255.0 {
  range 172.16.64.10 172.16.64.12;
  option routers 172.16.64.1;
  option domain-name-servers 172.16.64.1;
  option local-proxy-config "http://172.16.64.1/wpad.dat";
}
