### PR TITLE
Update Jackalope to remove references to RVM.

### DIFF
--- a/payloads/library/credentials/Jackalope/payload.txt
+++ b/payloads/library/credentials/Jackalope/payload.txt
@@ -7,7 +7,7 @@
 # Check readiness & prepare environment
 LED SETUP
 
-# REQUIRE-TOOL metasploit-framework
+REQUIRE-TOOL metasploit-framework
 ATTACKMODE HID RNDIS_ETHERNET
 
 # Ensure loot is available for recording results.

--- a/payloads/library/credentials/Jackalope/payload.txt
+++ b/payloads/library/credentials/Jackalope/payload.txt
@@ -7,7 +7,7 @@
 # Check readiness & prepare environment
 LED SETUP
 
-REQUIRE-TOOL metasploit-framework
+REQUIRETOOL metasploit-framework
 ATTACKMODE HID RNDIS_ETHERNET
 
 # Ensure loot is available for recording results.

--- a/payloads/library/credentials/Jackalope/payload.txt
+++ b/payloads/library/credentials/Jackalope/payload.txt
@@ -26,8 +26,6 @@ COUNT=$((COUNT+1))
 LOOTDIR=$LOOTBASE/$TARGET_HOSTNAME-$COUNT
 mkdir -p $LOOTDIR
 
-source /etc/profile.d/rvm.sh
-rvm --default use 2.6.2 >> $LOOTDIR/log.txt
 MSF_DIR=/tools/metasploit-framework
 
 # Save environment informaiton:


### PR DESCRIPTION
Starting with Firmware 1.6 and the Metasploit tools package, RVM will no longer be needed.