### PR TITLE
Changed QUACK to RUN

### DIFF
--- a/payloads/library/general/ExecutableInstaller/payload.txt
+++ b/payloads/library/general/ExecutableInstaller/payload.txt
@@ -15,8 +15,5 @@ LED SETUP
 GET SWITCH_POSITION
 LED ATTACK
 ATTACKMODE HID STORAGE
-QUACK GUI r
-QUACK DELAY 100
-QUACK STRING powershell ".((gwmi win32_volume -f 'label=''BashBunny''').Name+'payloads\\$SWITCH_POSITION\d.cmd')"
-QUACK ENTER
+RUN WIN "powershell \".((gwmi win32_volume -f 'label=''BashBunny''').Name+'payloads\\$SWITCH_POSITION\d.cmd')"\"
 LED FINISH


### PR DESCRIPTION
The lines, that open a Run window and enter the command using the QUACK have been replaced by a single line using the RUN command.