### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 /.project
 /payloads/library/DumpCreds_2.0/PS/Invoke-M1m1d0gz.ps1
+/payloads/switch1
+/payloads/switch2


### PR DESCRIPTION
Ignores switch payloads so updating the repo doesn't undo any payload choices.