### PR TITLE
Add GET BB_LABEL function and docs

### DIFF
--- a/docs/readme.txt
+++ b/docs/readme.txt
@@ -6,7 +6,7 @@
  Bash Bunny by Hak5                           USB Attack/Automation Platform
 
 
-                      -+- QUICK REFERENCE GUIDE v1.4 -+-
+                      -+- QUICK REFERENCE GUIDE v1.5 -+-
 
 
      +-----------------+
@@ -107,6 +107,8 @@
  $HOST_IP           IP Address of the Bash Bunny               
                     (Default: 172.16.64.1)                             
  $SWITCH_POSITION   "switch1", "switch2" or "switch3"
+ $BB_LABEL          Volume name of the BashBunny
+                    when mounted.
 
 
 
@@ -153,6 +155,8 @@
    GET TARGET_HOSTNAME   Returns $TARGET_HOSTNAME
    GET HOST_IP           Returns $HOST_IP
    GET SWITCH_POSITION   Returns $SWITCH_POSITION
+   GET TARGET_OS         Returns $TARGET_OS
+   GET BB_LABEL          Returns $BB_LABEL
 
 
            

--- a/payloads/extensions/get.sh
+++ b/payloads/extensions/get.sh
@@ -26,6 +26,10 @@ function GET() {
       [[ "${ScanForOS,,}" == *"linux"* ]] && export TARGET_OS='LINUX' && return
       export TARGET_OS='UNKNOWN'
       ;;
+      "BUNNY_LABEL")
+      export BUNNY_LABEL=$(ls -l /dev/disk/by-label/ | awk '/nandf$/ { print $9 }')
+      ;;
+
   esac
 }
 

--- a/payloads/extensions/get.sh
+++ b/payloads/extensions/get.sh
@@ -26,8 +26,8 @@ function GET() {
       [[ "${ScanForOS,,}" == *"linux"* ]] && export TARGET_OS='LINUX' && return
       export TARGET_OS='UNKNOWN'
       ;;
-      "BUNNY_LABEL")
-      export BUNNY_LABEL=$(ls -l /dev/disk/by-label/ | awk '/nandf$/ { print $9 }')
+      "BB_LABEL")
+      export BB_LABEL=$(ls -l /dev/disk/by-label/ | awk '/nandf$/ { print $9 }')
       ;;
 
   esac


### PR DESCRIPTION
Instead of hardcoding "BashBunny" or whatever new name the Bunny has, attackers can use a GET command.