### PR TITLE
Update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 .DS_Store
+version.txt
+loot/
+payloads-orig/
+System\ Volume\ Information/
+win7-win8-cdc-acm.inf
 /.project
 /payloads/library/DumpCreds_2.0/PS/Invoke-M1m1d0gz.ps1


### PR DESCRIPTION
Git will now ignore the following files
    1. files windows creates when connecting as a USB
    2. the entire loot directory
    3. the firmware version.txt file
    4. the payload-orig directory created during GitBunnyGit